### PR TITLE
fix crash on invalid keybind

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/KeyHandler.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/KeyHandler.java
@@ -62,7 +62,7 @@ public abstract class KeyHandler
         {
             KeyBinding keyBinding = this.keyBindings[i];
             int keyCode = keyBinding.getKeyCode();
-            if (keyCode == Keyboard.CHAR_NONE) continue;
+            if (keyCode == Keyboard.CHAR_NONE || keyCode > 255) continue;
             boolean state = inChat ? false : (keyCode < 0 ? Mouse.isButtonDown(keyCode + 100) : Keyboard.isKeyDown(keyCode));
             if (state != this.keyDown[i] || state && this.repeatings[i])
             {
@@ -84,7 +84,7 @@ public abstract class KeyHandler
         {
             KeyBinding keyBinding = this.vKeyBindings[i];
             int keyCode = keyBinding.getKeyCode();
-            if (keyCode == Keyboard.CHAR_NONE) continue;
+            if (keyCode == Keyboard.CHAR_NONE || keyCode > 255) continue;
             boolean state = keyCode < 0 ? Mouse.isButtonDown(keyCode + 100) : Keyboard.isKeyDown(keyCode);
             if (state != this.keyDown[i + this.keyBindings.length] || state && this.vRepeatings[i])
             {


### PR DESCRIPTION
keys over 255 simply get ignored instead of causing a crash