### PR TITLE
Fixes and new features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /reobf/*
 /runtime/*
 /temp/*
+/run/*
 LICENSE.txt
 CHANGELOG
 

--- a/src/main/java/micdoodle8/mods/galacticraft/api/entity/IFuelableTiered.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/entity/IFuelableTiered.java
@@ -1,0 +1,8 @@
+package micdoodle8.mods.galacticraft.api.entity;
+
+import net.minecraftforge.fluids.FluidStack;
+
+public interface IFuelableTiered extends IFuelable {
+
+    public int getRocketTier();
+}

--- a/src/main/java/micdoodle8/mods/galacticraft/api/prefab/entity/EntityAutoRocket.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/prefab/entity/EntityAutoRocket.java
@@ -443,6 +443,11 @@ public abstract class EntityAutoRocket extends EntitySpaceshipBase implements IL
         return false;
     }
 
+    public int fuelToDrain()
+    {
+        return (int)(this.getFuelTankCapacity() * ConfigManagerCore.rocketFuelFactor * 0.5);
+    }
+
     //Server side only - this is a Launch Controlled ignition attempt
     private void autoLaunch()
     {
@@ -462,8 +467,11 @@ public abstract class EntityAutoRocket extends EntitySpaceshipBase implements IL
 
             		if (autoLaunchEnabled != null && autoLaunchEnabled)
             		{
-            			if (this.fuelTank.getFluidAmount() > this.fuelTank.getCapacity() * 2 / 5)
-            				this.ignite();
+            			if (this.fuelTank.getFluidAmount() >= this.fuelToDrain())
+                        {
+                            this.setFrequency();
+                            this.ignite();
+                        }
             			else
             				this.failMessageInsufficientFuel();
             		}
@@ -487,6 +495,8 @@ public abstract class EntityAutoRocket extends EntitySpaceshipBase implements IL
     {
         if (this.destinationFrequency != -1)
         {
+            this.timeUntilLaunch = 100;
+            this.fuelTank.drain(fuelToDrain(), true);
             super.ignite();
             this.activeLaunchController = null;
             return true;

--- a/src/main/java/micdoodle8/mods/galacticraft/api/prefab/entity/EntityAutoRocket.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/prefab/entity/EntityAutoRocket.java
@@ -150,7 +150,7 @@ public abstract class EntityAutoRocket extends EntitySpaceshipBase implements IL
 
     public boolean setFrequency()
     {
-        if (!GalacticraftCore.isPlanetsLoaded || controllerClass == null)
+         if (!GalacticraftCore.isPlanetsLoaded || controllerClass == null)
         {
             return false;
         }
@@ -485,7 +485,7 @@ public abstract class EntityAutoRocket extends EntitySpaceshipBase implements IL
 
     public boolean igniteWithResult()
     {
-        if (this.setFrequency())
+        if (this.destinationFrequency != -1)
         {
             super.ignite();
             this.activeLaunchController = null;
@@ -798,7 +798,7 @@ public abstract class EntityAutoRocket extends EntitySpaceshipBase implements IL
 
     public boolean hasValidFuel()
     {
-        return this.fuelTank.getFluidAmount() > 0;
+        return false;
     }
 
     public void cancelLaunch()
@@ -1023,8 +1023,8 @@ public abstract class EntityAutoRocket extends EntitySpaceshipBase implements IL
 	            {
 	                this.updateControllerSettings(pad);
 	            }
+                this.landing = false;
 	    	}
-	        this.landing = false;
         }
     }
 

--- a/src/main/java/micdoodle8/mods/galacticraft/api/prefab/entity/EntitySpaceshipBase.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/prefab/entity/EntitySpaceshipBase.java
@@ -53,7 +53,6 @@ public abstract class EntitySpaceshipBase extends Entity implements IPacketRecei
     }
 
     public int launchPhase;
-
     protected long ticks = 0;
     protected double dragAir;
     public int timeUntilLaunch;
@@ -117,7 +116,7 @@ public abstract class EntitySpaceshipBase extends Entity implements IPacketRecei
         {
 			boolean flag = par1DamageSource.getEntity() instanceof EntityPlayer && ((EntityPlayer)par1DamageSource.getEntity()).capabilities.isCreativeMode;
         	Entity e = par1DamageSource.getEntity(); 
-            if (this.isEntityInvulnerable() || this.posY > 300 || (e instanceof EntityLivingBase && !(e instanceof EntityPlayer)))
+            if (this.isEntityInvulnerable() || this.posY > 255 || (!(e instanceof EntityPlayer)))
             {
                 return false;
             }
@@ -214,18 +213,18 @@ public abstract class EntitySpaceshipBase extends Entity implements IPacketRecei
 
         if (this.addToTelemetry)
         {
-        	this.addToTelemetry = false;
-			for (BlockVec3Dim vec : new ArrayList<BlockVec3Dim>(this.telemetryList))
-			{
-				TileEntity t1 = vec.getTileEntityNoLoad();
-				if (t1 instanceof TileEntityTelemetry && !t1.isInvalid())
-				{
-					if (((TileEntityTelemetry)t1).linkedEntity == this)
-						((TileEntityTelemetry)t1).addTrackedEntity(this);
-				}		
-			}
+            this.addToTelemetry = false;
+            for (BlockVec3Dim vec : new ArrayList<BlockVec3Dim>(this.telemetryList))
+            {
+                TileEntity t1 = vec.getTileEntityNoLoad();
+                if (t1 instanceof TileEntityTelemetry && !t1.isInvalid())
+                {
+                    if (((TileEntityTelemetry)t1).linkedEntity == this)
+                        ((TileEntityTelemetry)t1).addTrackedEntity(this);
+                }
+            }
         }
-        
+
         if (this.riddenByEntity != null)
         {
             this.riddenByEntity.fallDistance = 0.0F;
@@ -250,31 +249,30 @@ public abstract class EntitySpaceshipBase extends Entity implements IPacketRecei
 
         if (!this.worldObj.isRemote)
         {
-	        if (this.posY < 0.0D)
-	        {
-	            this.kill();
-	        }
-	        else
-	        if (this.posY > (this.worldObj.provider instanceof IExitHeight ? ((IExitHeight) this.worldObj.provider).getYCoordinateToTeleport() : 1200) + 100)
-	        {
-	        	if (this.riddenByEntity instanceof EntityPlayerMP)
-	        	{
-	        		GCPlayerStats stats = GCPlayerStats.get((EntityPlayerMP) this.riddenByEntity);
-	        		if (stats.usingPlanetSelectionGui)
-	        		{
-	        			this.kill();
-	        		}
-	        	}
-	        	else
-	        		this.kill();
-	        }
+            if (this.posY < 0.0D)
+            {
+                this.kill();
+            }
+            else if (this.posY > (this.worldObj.provider instanceof IExitHeight ? ((IExitHeight) this.worldObj.provider).getYCoordinateToTeleport() : 1200) + 100)
+            {
+                if (this.riddenByEntity instanceof EntityPlayerMP)
+                {
+                    GCPlayerStats stats = GCPlayerStats.get((EntityPlayerMP) this.riddenByEntity);
+                    if (stats.usingPlanetSelectionGui)
+                    {
+                        this.kill();
+                    }
+                }
+                else
+                    this.kill();
+            }
 
-	        if (this.timeSinceLaunch > 50 && this.onGround)
-	        {
-	            this.failRocket();
-	        }
+            if (this.timeSinceLaunch > 50 && this.onGround)
+            {
+                this.failRocket();
+            }
         }
-        
+
         if (this.launchPhase == EnumLaunchPhase.UNIGNITED.ordinal())
         {
             this.timeUntilLaunch = this.getPreLaunchWait();

--- a/src/main/java/micdoodle8/mods/galacticraft/api/prefab/entity/EntityTieredRocket.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/prefab/entity/EntityTieredRocket.java
@@ -99,10 +99,30 @@ public abstract class EntityTieredRocket extends EntityAutoRocket implements IRo
     {
         if (!this.worldObj.isRemote && this.launchCooldown <= 0)
         {
+            if (this.destinationFrequency != -1) {
+                this.timeUntilLaunch = 100;
+                this.fuelTank.drain(fuelToDrain(), true);
+            }
             this.initiatePlanetsPreGen(this.chunkCoordX, this.chunkCoordZ);
-
             this.ignite();
         }
+    }
+
+    @Override
+    public boolean hasValidFuel()
+    {
+        if (this.destinationFrequency != -1)
+        {
+            if (this.fuelTank.getFluidAmount() < fuelToDrain())
+                return false;
+            return true;
+        }
+        return this.fuelTank.getFluidAmount() > 0;
+    }
+
+    public int fuelToDrain()
+    {
+        return (int)(this.getFuelTankCapacity() * ConfigManagerCore.rocketFuelFactor * 0.25);
     }
 
     private void initiatePlanetsPreGen(int cx, int cz)
@@ -256,12 +276,20 @@ public abstract class EntityTieredRocket extends EntityAutoRocket implements IRo
             this.riddenByEntity.posX += rumbleAmount;
             this.riddenByEntity.posZ += rumbleAmount;
         }
+        boolean isIgnited = this.launchPhase == EnumLaunchPhase.IGNITED.ordinal();
+        boolean isLaunched = this.launchPhase == EnumLaunchPhase.LAUNCHED.ordinal();
 
-        if (this.launchPhase == EnumLaunchPhase.IGNITED.ordinal() || this.launchPhase == EnumLaunchPhase.LAUNCHED.ordinal())
+        if (isIgnited || isLaunched)
         {
             this.performHurtAnimation();
-
             this.rumble = (float) this.rand.nextInt(3) - 3;
+
+            if (this.destinationFrequency != -1
+                    && this.landing == false
+                    && isLaunched)
+            {
+                onReachAtmosphere();
+            }
         }
 
         if (!this.worldObj.isRemote)
@@ -359,7 +387,11 @@ public abstract class EntityTieredRocket extends EntityAutoRocket implements IRo
                     		    Entity e = WorldUtil.transferEntityToDimension(this, this.targetDimension, (WorldServer)targetDim.worldObj, false, null);
                     		    if(e instanceof EntityAutoRocket)
                     		    {
-                    		        e.setPosition(this.targetVec.x + 0.5F, this.targetVec.y + 800, this.targetVec.z + 0.5f);
+                                    int fromSky = 800;
+                                    if (this.destinationFrequency != 1){
+                                        fromSky = 0;
+                                    }
+                    		        e.setPosition(this.targetVec.x + 0.5F, this.targetVec.y + fromSky, this.targetVec.z + 0.5f);
                     		        ((EntityAutoRocket)e).landing = true;
                     		        ((EntityAutoRocket)e).setWaitForPlayer(false);
                     		    }
@@ -377,7 +409,11 @@ public abstract class EntityTieredRocket extends EntityAutoRocket implements IRo
                 else
                 {
                 	//Same dimension controlled rocket flight
-                	this.setPosition(this.targetVec.x + 0.5F, this.targetVec.y + 800, this.targetVec.z + 0.5F);
+                    int fromSky = 800;
+                    if (this.destinationFrequency != 1){
+                        fromSky = 0;
+                    }
+                	this.setPosition(this.targetVec.x + 0.5F, this.targetVec.y + fromSky, this.targetVec.z + 0.5F);
                     //Stop any lateral motion, otherwise it will update to an incorrect x,z position first tick after spawning above target
                     this.motionX = this.motionZ = 0.0D;
                     //Small upward motion initially, to keep clear of own flame trail from launch
@@ -424,6 +460,7 @@ public abstract class EntityTieredRocket extends EntityAutoRocket implements IRo
     @Override
     protected boolean shouldCancelExplosion()
     {
+
         return this.hasValidFuel() && Math.abs(this.lastLastMotionY) < 4;
     }
 
@@ -518,7 +555,11 @@ public abstract class EntityTieredRocket extends EntityAutoRocket implements IRo
     {
         if (this.targetVec != null)
         {
-            this.setPosition(this.targetVec.x + 0.5F, this.targetVec.y + 800, this.targetVec.z + 0.5F);
+            int fromSky = 800;
+            if (this.destinationFrequency != 1){
+                fromSky = 0;
+            }
+            this.setPosition(this.targetVec.x + 0.5F, this.targetVec.y + fromSky, this.targetVec.z + 0.5F);
             this.landing = true;
             this.setWaitForPlayer(true);
             this.motionX = this.motionY = this.motionZ = 0.0D;

--- a/src/main/java/micdoodle8/mods/galacticraft/api/prefab/entity/EntityTieredRocket.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/prefab/entity/EntityTieredRocket.java
@@ -99,8 +99,12 @@ public abstract class EntityTieredRocket extends EntityAutoRocket implements IRo
     {
         if (!this.worldObj.isRemote && this.launchCooldown <= 0)
         {
-            this.initiatePlanetsPreGen(this.chunkCoordX, this.chunkCoordZ);
-            this.ignite();
+            if (this.launchPhase != EnumLaunchPhase.IGNITED.ordinal())
+            {
+                this.setFrequency();
+                this.initiatePlanetsPreGen(this.chunkCoordX, this.chunkCoordZ);
+                this.ignite();
+            }
         }
     }
 
@@ -547,7 +551,7 @@ public abstract class EntityTieredRocket extends EntityAutoRocket implements IRo
         if (this.targetVec != null)
         {
             int fromSky = 800;
-            if (this.destinationFrequency != 1){
+            if (this.destinationFrequency != -1){
                 fromSky = 0;
             }
             this.setPosition(this.targetVec.x + 0.5F, this.targetVec.y + fromSky, this.targetVec.z + 0.5F);

--- a/src/main/java/micdoodle8/mods/galacticraft/api/prefab/entity/EntityTieredRocket.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/prefab/entity/EntityTieredRocket.java
@@ -122,7 +122,7 @@ public abstract class EntityTieredRocket extends EntityAutoRocket implements IRo
 
     public int fuelToDrain()
     {
-        return (int)(this.getFuelTankCapacity() * ConfigManagerCore.rocketFuelFactor * 0.25);
+        return (int)(this.getFuelTankCapacity() * ConfigManagerCore.rocketFuelFactor * 0.5);
     }
 
     private void initiatePlanetsPreGen(int cx, int cz)

--- a/src/main/java/micdoodle8/mods/galacticraft/api/prefab/entity/EntityTieredRocket.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/prefab/entity/EntityTieredRocket.java
@@ -99,10 +99,6 @@ public abstract class EntityTieredRocket extends EntityAutoRocket implements IRo
     {
         if (!this.worldObj.isRemote && this.launchCooldown <= 0)
         {
-            if (this.destinationFrequency != -1) {
-                this.timeUntilLaunch = 100;
-                this.fuelTank.drain(fuelToDrain(), true);
-            }
             this.initiatePlanetsPreGen(this.chunkCoordX, this.chunkCoordZ);
             this.ignite();
         }
@@ -118,11 +114,6 @@ public abstract class EntityTieredRocket extends EntityAutoRocket implements IRo
             return true;
         }
         return this.fuelTank.getFluidAmount() > 0;
-    }
-
-    public int fuelToDrain()
-    {
-        return (int)(this.getFuelTankCapacity() * ConfigManagerCore.rocketFuelFactor * 0.5);
     }
 
     private void initiatePlanetsPreGen(int cx, int cz)

--- a/src/main/java/micdoodle8/mods/galacticraft/api/recipe/RocketFuel.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/recipe/RocketFuel.java
@@ -22,4 +22,8 @@ public class RocketFuel
     {
         return fluid.getFluidID() == fluidId;
     }
+    public boolean isFluidEqual(Fluid fluid)
+    {
+        return fluid.getID() == fluidId;
+    }
 }

--- a/src/main/java/micdoodle8/mods/galacticraft/api/recipe/RocketFuel.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/recipe/RocketFuel.java
@@ -1,0 +1,25 @@
+package micdoodle8.mods.galacticraft.api.recipe;
+
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidStack;
+
+public class RocketFuel
+{
+    private int fluidId;
+    private int maxTier;
+
+    public RocketFuel(int fluidId, int maxTier)
+    {
+        this.fluidId = fluidId;
+        this.maxTier = maxTier;
+    }
+
+    public int getMaxTier()
+    {
+        return maxTier;
+    }
+    public boolean isFluidEqual(FluidStack fluid)
+    {
+        return fluid.getFluidID() == fluidId;
+    }
+}

--- a/src/main/java/micdoodle8/mods/galacticraft/api/recipe/RocketFuelRecipe.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/recipe/RocketFuelRecipe.java
@@ -25,10 +25,13 @@ public class RocketFuelRecipe
 
     public static boolean isValidFuel(FluidStack fluid)
     {
-        for(RocketFuel fuel : fuelList)
+        if (fluid != null)
         {
-            if (fuel.isFluidEqual(fluid))
-                return true;
+            for(RocketFuel fuel : fuelList)
+            {
+                if (fuel.isFluidEqual(fluid))
+                    return true;
+            }
         }
         return false;
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/api/recipe/RocketFuelRecipe.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/recipe/RocketFuelRecipe.java
@@ -1,7 +1,6 @@
 package micdoodle8.mods.galacticraft.api.recipe;
 
 import java.util.ArrayList;
-import java.util.List;
 import micdoodle8.mods.galacticraft.api.recipe.RocketFuel;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
@@ -21,6 +20,25 @@ public class RocketFuelRecipe
     public static void addFuel(String name,int MaxTier)
     {
         addFuel(FluidRegistry.getFluid(name),MaxTier);
+    }
+
+    public static  void removeFuel(String fluidName)
+    {
+        removeFuel(FluidRegistry.getFluid(fluidName));
+    }
+
+    public static  void removeFuel(Fluid fluid)
+    {
+        if (fluid != null)
+        {
+            for(int i = 0;i<fuelList.size();i++)
+            {
+                if (fuelList.get(i).isFluidEqual(fluid))
+                {
+                    fuelList.remove(i);
+                }
+            }
+        }
     }
 
     public static boolean isValidFuel(FluidStack fluid)

--- a/src/main/java/micdoodle8/mods/galacticraft/api/recipe/RocketFuelRecipe.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/recipe/RocketFuelRecipe.java
@@ -1,0 +1,49 @@
+package micdoodle8.mods.galacticraft.api.recipe;
+
+import java.util.ArrayList;
+import java.util.List;
+import micdoodle8.mods.galacticraft.api.recipe.RocketFuel;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
+
+public class RocketFuelRecipe
+{
+    public static ArrayList<RocketFuel> fuelList = new ArrayList<RocketFuel>();
+
+    public static void addFuel(Fluid fluid, int MaxTier)
+    {
+        if (fluid != null)
+        {
+            fuelList.add(new RocketFuel(fluid.getID(), MaxTier));
+        }
+    }
+    public static void addFuel(String name,int MaxTier)
+    {
+        addFuel(FluidRegistry.getFluid(name),MaxTier);
+    }
+
+    public static boolean isValidFuel(FluidStack fluid)
+    {
+        for(RocketFuel fuel : fuelList)
+        {
+            if (fuel.isFluidEqual(fluid))
+                return true;
+        }
+        return false;
+    }
+
+    public static int getfuelMaxTier(FluidStack fluid)
+    {
+        if (fluid == null)
+            return 0;
+        for(RocketFuel fuel : fuelList)
+        {
+            if (fuel.isFluidEqual(fluid))
+            {
+                return fuel.getMaxTier();
+            }
+        }
+        return 0;
+    }
+}

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/gui/container/GuiFuelLoader.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/gui/container/GuiFuelLoader.java
@@ -1,5 +1,6 @@
 package micdoodle8.mods.galacticraft.core.client.gui.container;
 
+import micdoodle8.mods.galacticraft.api.recipe.RocketFuelRecipe;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.client.gui.element.GuiElementInfoRegion;
 import micdoodle8.mods.galacticraft.core.energy.EnergyDisplayHelper;
@@ -9,6 +10,7 @@ import micdoodle8.mods.galacticraft.core.network.PacketSimple.EnumSimplePacket;
 import micdoodle8.mods.galacticraft.core.tile.TileEntityFuelLoader;
 import micdoodle8.mods.galacticraft.core.util.EnumColor;
 import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
+import micdoodle8.mods.galacticraft.core.util.GCLog;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.util.ResourceLocation;
@@ -87,7 +89,10 @@ public class GuiFuelLoader extends GuiContainerGC
         {
             return EnumColor.DARK_RED + GCCoreUtil.translate("gui.status.nofuel.name");
         }
-
+        if (!this.fuelLoader.coorectTier)
+        {
+            return EnumColor.DARK_RED + GCCoreUtil.translate("gui.status.lowtier.name");
+        }
         return this.fuelLoader.getGUIstatus();
     }
 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/entities/EntityLanderBase.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/entities/EntityLanderBase.java
@@ -86,13 +86,23 @@ public abstract class EntityLanderBase extends EntityAdvancedMotion implements I
 
         GCPlayerStats stats = GCPlayerStats.get(player);
         this.containedItems = new ItemStack[stats.rocketStacks.length + 1];
-        this.fuelTank.setFluid(new FluidStack(GalacticraftCore.fluidFuel, stats.fuelLevel));
-
+//        this.fuelTank.setFluid(new FluidStack(GalacticraftCore.fluidFuel, stats.fuelLevel));
+//        ItemStack rocket = new ItemStack(stats.rocketItem, 1, stats.rocketType);
         for (int i = 0; i < stats.rocketStacks.length; i++)
         {
             if (stats.rocketStacks[i] != null)
             {
-                this.containedItems[i] = stats.rocketStacks[i].copy();
+                ItemStack item = stats.rocketStacks[i].copy();
+//                if (item.isItemEqual(rocket))
+//                {
+//                    NBTTagCompound nbt = new NBTTagCompound();
+//                    nbt.setInteger("RocketFuel",stats.fuelLevel);
+//                    rocket.setTagCompound(nbt);
+//                    item = rocket;
+//                }
+                this.containedItems[i] = item;
+
+
             }
             else
             {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/entities/EntityTier1Rocket.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/entities/EntityTier1Rocket.java
@@ -123,7 +123,7 @@ public class EntityTier1Rocket extends EntityTieredRocket
 					this.stopRocketSound();
             }
         }
-        else if (!this.hasValidFuel() && this.getLaunched() && !this.worldObj.isRemote)
+        else if (!this.worldObj.isRemote && this.getLaunched() && !this.hasValidFuel())
         {
             if (Math.abs(Math.sin(this.timeSinceLaunch / 1000)) / 10 != 0.0)
             {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/entities/player/GCPlayerStats.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/entities/player/GCPlayerStats.java
@@ -19,8 +19,11 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.world.World;
 import net.minecraftforge.common.IExtendedEntityProperties;
+
 import java.lang.ref.WeakReference;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 
 public class GCPlayerStats implements IExtendedEntityProperties
 {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/network/PacketSimple.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/network/PacketSimple.java
@@ -874,24 +874,14 @@ public class PacketSimple extends Packet implements IPacket
             if (!player.worldObj.isRemote && !player.isDead && player.ridingEntity != null && !player.ridingEntity.isDead && player.ridingEntity instanceof EntityTieredRocket)
             {
                 final EntityTieredRocket ship = (EntityTieredRocket) player.ridingEntity;
-                ship.setFrequency();
+
                 if (!ship.landing)
                 {
-                    if (ship.hasValidFuel())
-                    {
-                        ItemStack stack2 = stats.extendedInventory.getStackInSlot(4);
 
-                        if (stack2 != null && stack2.getItem() instanceof ItemParaChute || stats.launchAttempts > 0)
-                        {
-                            ship.igniteCheckingCooldown();
-                            stats.launchAttempts = 0;
-                        }
-                        else if (stats.chatCooldown == 0 && stats.launchAttempts == 0)
-                        {
-                            player.addChatMessage(new ChatComponentText(GCCoreUtil.translate("gui.rocket.warning.noparachute")));
-                            stats.chatCooldown = 250;
-                            stats.launchAttempts = 1;
-                        }
+                    if (ship.hasValidFuel())
+                    {   
+                        ship.igniteCheckingCooldown();
+                        stats.launchAttempts = 0;
                     }
                     else if (stats.chatCooldown == 0)
                     {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/network/PacketSimple.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/network/PacketSimple.java
@@ -874,7 +874,7 @@ public class PacketSimple extends Packet implements IPacket
             if (!player.worldObj.isRemote && !player.isDead && player.ridingEntity != null && !player.ridingEntity.isDead && player.ridingEntity instanceof EntityTieredRocket)
             {
                 final EntityTieredRocket ship = (EntityTieredRocket) player.ridingEntity;
-
+                ship.setFrequency();
                 if (!ship.landing)
                 {
                     if (ship.hasValidFuel())

--- a/src/main/java/micdoodle8/mods/galacticraft/core/recipe/RecipeManagerGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/recipe/RecipeManagerGC.java
@@ -73,12 +73,8 @@ public class RecipeManagerGC
             RocketFuelRecipe.addFuel("fluid.rocketfuelmixd",4);
 
         }
-        //cetena
-        RocketFuelRecipe.addFuel("nitrofuel",1);
-        RocketFuelRecipe.addFuel("plasma.nitrogen",8);
-        RocketFuelRecipe.addFuel("highoctanegasoline",5);
         //eio rocket fuel
-        RocketFuelRecipe.addFuel("rocket_fuel",5);
+        RocketFuelRecipe.addFuel("rocket_fuel",8);
 
 
         Object meteoricIronIngot = ConfigManagerCore.recipesRequireGCAdvancedMetals ? GCItems.meteoricIronIngot : "ingotMeteoricIron";

--- a/src/main/java/micdoodle8/mods/galacticraft/core/recipe/RecipeManagerGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/recipe/RecipeManagerGC.java
@@ -75,7 +75,7 @@ public class RecipeManagerGC
         }
         //cetena
         RocketFuelRecipe.addFuel("nitrofuel",1);
-        RocketFuelRecipe.addFuel("plasma.zinc",8);
+        RocketFuelRecipe.addFuel("plasma.nitrogen",8);
         RocketFuelRecipe.addFuel("highoctanegasoline",5);
         //eio rocket fuel
         RocketFuelRecipe.addFuel("rocket_fuel",5);

--- a/src/main/java/micdoodle8/mods/galacticraft/core/recipe/RecipeManagerGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/recipe/RecipeManagerGC.java
@@ -73,12 +73,19 @@ public class RecipeManagerGC
             RocketFuelRecipe.addFuel("fluid.rocketfuelmixd",4);
 
         }
+        //cetena
+        RocketFuelRecipe.addFuel("nitrofuel",1);
+        RocketFuelRecipe.addFuel("plasma.zinc",8);
+        RocketFuelRecipe.addFuel("highoctanegasoline",5);
+        //eio rocket fuel
+        RocketFuelRecipe.addFuel("rocket_fuel",5);
+
 
         Object meteoricIronIngot = ConfigManagerCore.recipesRequireGCAdvancedMetals ? GCItems.meteoricIronIngot : "ingotMeteoricIron";
     	Object meteoricIronPlate = ConfigManagerCore.recipesRequireGCAdvancedMetals ? new ItemStack(GCItems.meteoricIronIngot, 1, 1) : "compressedMeteoricIron";
     	Object deshIngot = GalacticraftCore.isPlanetsLoaded ? (ConfigManagerCore.recipesRequireGCAdvancedMetals ? new ItemStack(MarsItems.marsItemBasic, 1, 2) : "ingotDesh") : GCItems.heavyPlatingTier1;
 
-        //RocketFuelRecipe.addFuel(GalacticraftCore.fluidFuel,1);
+        RocketFuelRecipe.addFuel(GalacticraftCore.fluidFuel,1);
     	FurnaceRecipes.smelting().func_151394_a(new ItemStack(GCBlocks.basicBlock, 1, 5), new ItemStack(GCItems.basicItem, 1, 3), 0.5F);
         FurnaceRecipes.smelting().func_151394_a(new ItemStack(GCBlocks.basicBlock, 1, 6), new ItemStack(GCItems.basicItem, 1, 4), 0.5F);
         FurnaceRecipes.smelting().func_151394_a(new ItemStack(GCBlocks.basicBlock, 1, 7), new ItemStack(GCItems.basicItem, 1, 5), 0.5F);

--- a/src/main/java/micdoodle8/mods/galacticraft/core/recipe/RecipeManagerGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/recipe/RecipeManagerGC.java
@@ -1,8 +1,10 @@
 package micdoodle8.mods.galacticraft.core.recipe;
 
+import cpw.mods.fml.common.Loader;
 import micdoodle8.mods.galacticraft.api.GalacticraftRegistry;
 import micdoodle8.mods.galacticraft.api.recipe.CircuitFabricatorRecipes;
 import micdoodle8.mods.galacticraft.api.recipe.CompressorRecipes;
+import micdoodle8.mods.galacticraft.api.recipe.RocketFuelRecipe;
 import micdoodle8.mods.galacticraft.api.recipe.SpaceStationRecipe;
 import micdoodle8.mods.galacticraft.api.world.SpaceStationType;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
@@ -22,6 +24,7 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.item.crafting.FurnaceRecipes;
+import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.ShapelessOreRecipe;
 
@@ -61,10 +64,21 @@ public class RecipeManagerGC
     @SuppressWarnings("unchecked")
     private static void addUniversalRecipes()
     {
-    	Object meteoricIronIngot = ConfigManagerCore.recipesRequireGCAdvancedMetals ? GCItems.meteoricIronIngot : "ingotMeteoricIron";
+
+        if (Loader.isModLoaded("miscutils"))
+        {
+            RocketFuelRecipe.addFuel("fluid.rocketfuelmixa",8);
+            RocketFuelRecipe.addFuel("fluid.rocketfuelmixb",2);
+            RocketFuelRecipe.addFuel("fluid.rocketfuelmixc",6);
+            RocketFuelRecipe.addFuel("fluid.rocketfuelmixd",4);
+
+        }
+
+        Object meteoricIronIngot = ConfigManagerCore.recipesRequireGCAdvancedMetals ? GCItems.meteoricIronIngot : "ingotMeteoricIron";
     	Object meteoricIronPlate = ConfigManagerCore.recipesRequireGCAdvancedMetals ? new ItemStack(GCItems.meteoricIronIngot, 1, 1) : "compressedMeteoricIron";
     	Object deshIngot = GalacticraftCore.isPlanetsLoaded ? (ConfigManagerCore.recipesRequireGCAdvancedMetals ? new ItemStack(MarsItems.marsItemBasic, 1, 2) : "ingotDesh") : GCItems.heavyPlatingTier1;
-    	
+
+        //RocketFuelRecipe.addFuel(GalacticraftCore.fluidFuel,1);
     	FurnaceRecipes.smelting().func_151394_a(new ItemStack(GCBlocks.basicBlock, 1, 5), new ItemStack(GCItems.basicItem, 1, 3), 0.5F);
         FurnaceRecipes.smelting().func_151394_a(new ItemStack(GCBlocks.basicBlock, 1, 6), new ItemStack(GCItems.basicItem, 1, 4), 0.5F);
         FurnaceRecipes.smelting().func_151394_a(new ItemStack(GCBlocks.basicBlock, 1, 7), new ItemStack(GCItems.basicItem, 1, 5), 0.5F);

--- a/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityLandingPad.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityLandingPad.java
@@ -3,10 +3,8 @@ package micdoodle8.mods.galacticraft.core.tile;
 import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import micdoodle8.mods.galacticraft.api.entity.ICargoEntity;
-import micdoodle8.mods.galacticraft.api.entity.IDockable;
-import micdoodle8.mods.galacticraft.api.entity.IFuelable;
-import micdoodle8.mods.galacticraft.api.entity.ILandable;
+import micdoodle8.mods.galacticraft.api.entity.*;
+import micdoodle8.mods.galacticraft.api.prefab.entity.EntityTieredRocket;
 import micdoodle8.mods.galacticraft.api.tile.IFuelDock;
 import micdoodle8.mods.galacticraft.api.tile.ILandingPadAttachable;
 import micdoodle8.mods.galacticraft.api.vector.BlockVec3;
@@ -26,7 +24,7 @@ import net.minecraftforge.fluids.FluidStack;
 import java.util.HashSet;
 import java.util.List;
 
-public class TileEntityLandingPad extends TileEntityMulti implements IMultiBlock, IFuelable, IFuelDock, ICargoEntity
+public class TileEntityLandingPad extends TileEntityMulti implements IMultiBlock, IFuelableTiered, IFuelDock, ICargoEntity
 {
     private IDockable dockedEntity;
 
@@ -152,6 +150,19 @@ public class TileEntityLandingPad extends TileEntityMulti implements IMultiBlock
         }
 
         return null;
+    }
+
+    @Override
+    public int getRocketTier()
+    {
+        if (this.dockedEntity != null)
+        {
+            if (this.dockedEntity instanceof EntityTieredRocket)
+            {
+                return ((EntityTieredRocket)this.dockedEntity).getRocketTier();
+            }
+        }
+        return 0;
     }
 
     @Override

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/WorldUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/WorldUtil.java
@@ -1255,7 +1255,7 @@ public class WorldUtil
         {
             if (dimChange) FMLCommonHandler.instance().firePlayerChangedDimensionEvent((EntityPlayerMP) entity, oldDimID, dimID);
             //Spawn in a lander if appropriate
-            if (!(ridingRocket != null))
+            if (ridingRocket == null)
             {
                 type.onSpaceDimensionChanged(worldNew, (EntityPlayerMP) entity, ridingRocket != null);
             }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/WorldUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/WorldUtil.java
@@ -1255,7 +1255,11 @@ public class WorldUtil
         {
             if (dimChange) FMLCommonHandler.instance().firePlayerChangedDimensionEvent((EntityPlayerMP) entity, oldDimID, dimID);
             //Spawn in a lander if appropriate
-            type.onSpaceDimensionChanged(worldNew, (EntityPlayerMP) entity, ridingRocket != null);
+            if (!(ridingRocket != null))
+            {
+                type.onSpaceDimensionChanged(worldNew, (EntityPlayerMP) entity, ridingRocket != null);
+            }
+
         }
 
         return entity;

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/WorldUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/WorldUtil.java
@@ -1198,7 +1198,12 @@ public class WorldUtil
                             {
                                 if (playerStats.rocketItem != null)
                                 {
-                                    playerStats.rocketStacks[stack] = new ItemStack(playerStats.rocketItem, 1, playerStats.rocketType);
+                                    ItemStack rocket = new ItemStack(playerStats.rocketItem, 1, playerStats.rocketType);
+                                    NBTTagCompound nbt = new NBTTagCompound();
+                                    nbt.setInteger("RocketFuel",playerStats.fuelLevel);
+                                    rocket.setTagCompound(nbt);
+                                    playerStats.fuelLevel = 0;
+                                    playerStats.rocketStacks[stack] = rocket;
                                 }
                             }
                             else if (stack == playerStats.rocketStacks.length - 2)

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/entities/EntityCargoRocket.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/entities/EntityCargoRocket.java
@@ -325,7 +325,7 @@ public class EntityCargoRocket extends EntityAutoRocket implements IRocketType, 
     {
         if (this.targetVec != null)
         {
-            this.setPosition(this.targetVec.x + 0.5F, this.targetVec.y + 800, this.targetVec.z + 0.5F);
+            this.setPosition(this.targetVec.x + 0.5F, this.targetVec.y + 2, this.targetVec.z + 0.5F);
             this.landing = true;
         }
         else

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/network/PacketSimpleMars.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/network/PacketSimpleMars.java
@@ -303,15 +303,7 @@ public class PacketSimpleMars implements IPacket
             if (entity2 instanceof EntityCargoRocket)
             {
                 EntityCargoRocket rocket = (EntityCargoRocket) entity2;
-
-                int subType = (Integer) this.data.get(1);
-
-                switch (subType)
-                {
-                default:
-                    rocket.statusValid = rocket.checkLaunchValidity();
-                    break;
-                }
+                rocket.statusValid = rocket.checkLaunchValidity();
             }
             break;
         default:

--- a/src/main/resources/assets/galacticraftcore/lang/en_GB.lang
+++ b/src/main/resources/assets/galacticraftcore/lang/en_GB.lang
@@ -351,6 +351,7 @@ gui.status.sealed.name=Sealed
 gui.status.unknown.name=Unknown
 gui.status.disabled.name=Disabled
 gui.status.nofuel.name=No Fuel to Load!
+gui.status.lowtier.name=Fuel is too Low Quality!
 gui.status.noitems.name=No Items to Load!
 gui.status.notargetload.name=No Target to Load Into!
 gui.status.notargetunload.name=No Target to Unload!

--- a/src/main/resources/assets/galacticraftcore/lang/en_US.lang
+++ b/src/main/resources/assets/galacticraftcore/lang/en_US.lang
@@ -321,6 +321,7 @@ gui.status.sealed.name=Sealed
 gui.status.unknown.name=Unknown
 gui.status.disabled.name=Disabled
 gui.status.nofuel.name=No Fuel to Load!
+gui.status.lowtier.name=Fuel is too Low Quality!
 gui.status.noitems.name=No Items to Load!
 gui.status.notargetload.name=No Target to Load Into!
 gui.status.notargetunload.name=No Target to Unload!


### PR DESCRIPTION
makes rocket not take damge from non players
add api to make fluids seen as rocket fuel and tier them
made fueler faster
the lander will now drop with the rocket fueled with the rest of thefuel instead of puting the rest of the fuel in the lander
using a launchcontroller will now reduse countdown and instently teleport the rocket