### PR TITLE
Update EventHandlerGC.java

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/event/EventHandlerGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/event/EventHandlerGC.java
@@ -119,7 +119,35 @@ public class EventHandlerGC
     @SubscribeEvent
     public void onWorldSave(Save event)
     {
-        ChunkLoadingCallback.save((WorldServer) event.world);
+        //ChunkLoadingCallback.save((WorldServer) event.world);
+        counter.incrementAndGet();
+        if (thread == null) {
+            thread = new SaveThread();
+            thread.start();
+        }
+    }
+
+    public static AtomicInteger counter = new AtomicInteger(0);
+    public static SaveThread thread;
+    public static class SaveThread extends Thread {
+        public SaveThread() {
+            super("GC-SaveThread");
+        }
+
+        @Override
+        public void run() {
+            while (true) {
+                if (counter.get() >= 1) {
+                    ChunkLoadingCallback.save(null);
+                    counter.set(0);
+                }
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
     }
 
     @SubscribeEvent


### PR DESCRIPTION
After performance profiling, this is an important Server Lag spike (Server totally no response for ~3s in every ~30s, even in SSP), because of the function it calls has many for's and IOs, and this kind of file-saving for should be fine in another thread.I used this modified version for about 1 year and no problem happened.