### PR TITLE
Update NetworkRenderer.java

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/NetworkRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/NetworkRenderer.java
@@ -15,15 +15,18 @@ import java.util.List;
 
 public class NetworkRenderer
 {
+    static long t = -1;
+    static List<TileEntityBeamOutput> nodes = new ArrayList<TileEntityBeamOutput>();
+
     public static void renderNetworks(World world, float partialTicks)
     {
-        List<TileEntityBeamOutput> nodes = new ArrayList<TileEntityBeamOutput>();
-
-        for (Object o : new ArrayList<TileEntity>(world.loadedTileEntityList))
-        {
-            if (o instanceof TileEntityBeamOutput)
-            {
-                nodes.add((TileEntityBeamOutput) o);
+        if (System.currentTimeMillis() > t + 1000) {
+            t = System.currentTimeMillis();
+            nodes.clear();
+            for (Object o : new ArrayList<TileEntity>(world.loadedTileEntityList)) {
+                if (o instanceof TileEntityBeamOutput) {
+                    nodes.add((TileEntityBeamOutput) o);
+                }
             }
         }
 


### PR DESCRIPTION
After performance profiling, this change makes fps gain by 2%.
it is not useful to iterate through all the tileentities in the world in every frame, just renew it once per second is OK.