### PR TITLE
Removed recipes that are handled by GalaxySpace

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/GalacticraftCore.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/GalacticraftCore.java
@@ -292,10 +292,9 @@ public class GalacticraftCore
         ForgeChunkManager.setForcedChunkLoadingCallback(GalacticraftCore.instance, new ChunkLoadingCallback());
         FMLCommonHandler.instance().bus().register(new ConnectionEvents());
 
-        //Handled by GalaxySpace
-        /*SchematicRegistry.registerSchematicRecipe(new SchematicRocketT1());
+        SchematicRegistry.registerSchematicRecipe(new SchematicRocketT1());
         SchematicRegistry.registerSchematicRecipe(new SchematicMoonBuggy());
-        SchematicRegistry.registerSchematicRecipe(new SchematicAdd());*/
+        SchematicRegistry.registerSchematicRecipe(new SchematicAdd());
         ChunkPowerHandler.initiate();
         EnergyConfigHandler.initGas();
 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/GalacticraftCore.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/GalacticraftCore.java
@@ -162,7 +162,7 @@ import cpw.mods.fml.common.event.FMLServerStoppedEvent;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.registry.GameRegistry;
 
-@Mod(modid = Constants.MOD_ID_CORE, name = GalacticraftCore.NAME, version = Constants.LOCALMAJVERSION + "." + Constants.LOCALMINVERSION + "." + Constants.LOCALBUILDVERSION, acceptedMinecraftVersions = "[1.7.2],[1.7.10]", useMetadata = true, dependencies = "required-after:Forge@[10.12.2.1147,); required-after:FML@[7.2.217.1147,); required-after:Micdoodlecore; after:IC2; after:TConstruct; after:Mantle; after:BuildCraft|Core; after:BuildCraft|Energy; after:PlayerAPI@[1.3,)", guiFactory = "micdoodle8.mods.galacticraft.core.client.gui.screen.ConfigGuiFactoryCore")
+@Mod(modid = Constants.MOD_ID_CORE, name = GalacticraftCore.NAME, version = Constants.LOCALMAJVERSION + "." + Constants.LOCALMINVERSION + "." + Constants.LOCALBUILDVERSION, acceptedMinecraftVersions = "[1.7.2],[1.7.10]", useMetadata = true, dependencies = "required-after:Forge@[10.12.2.1147,); required-after:FML@[7.2.217.1147,); required-after:Micdoodlecore; required-before:GalaxySpace; after:IC2; after:TConstruct; after:Mantle; after:BuildCraft|Core; after:BuildCraft|Energy; after:PlayerAPI@[1.3,)", guiFactory = "micdoodle8.mods.galacticraft.core.client.gui.screen.ConfigGuiFactoryCore")
 public class GalacticraftCore
 {
     public static final String NAME = "Galacticraft Core";

--- a/src/main/java/micdoodle8/mods/galacticraft/core/GalacticraftCore.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/GalacticraftCore.java
@@ -292,9 +292,10 @@ public class GalacticraftCore
         ForgeChunkManager.setForcedChunkLoadingCallback(GalacticraftCore.instance, new ChunkLoadingCallback());
         FMLCommonHandler.instance().bus().register(new ConnectionEvents());
 
-        SchematicRegistry.registerSchematicRecipe(new SchematicRocketT1());
+        //Handled by GalaxySpace
+        /*SchematicRegistry.registerSchematicRecipe(new SchematicRocketT1());
         SchematicRegistry.registerSchematicRecipe(new SchematicMoonBuggy());
-        SchematicRegistry.registerSchematicRecipe(new SchematicAdd());
+        SchematicRegistry.registerSchematicRecipe(new SchematicAdd());*/
         ChunkPowerHandler.initiate();
         EnergyConfigHandler.initGas();
 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/nei/NEIGalacticraftConfig.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/nei/NEIGalacticraftConfig.java
@@ -51,10 +51,11 @@ public class NEIGalacticraftConfig implements IConfigureNEI
             }
         }
 
-        API.registerRecipeHandler(new RocketT1RecipeHandler());
+        //Handled by GalaxySpace
+        /*API.registerRecipeHandler(new RocketT1RecipeHandler());
         API.registerUsageHandler(new RocketT1RecipeHandler());
         API.registerRecipeHandler(new BuggyRecipeHandler());
-        API.registerUsageHandler(new BuggyRecipeHandler());
+        API.registerUsageHandler(new BuggyRecipeHandler());*/
         API.registerRecipeHandler(new RefineryRecipeHandler());
         API.registerUsageHandler(new RefineryRecipeHandler());
         API.registerRecipeHandler(new CircuitFabricatorRecipeHandler());
@@ -134,8 +135,9 @@ public class NEIGalacticraftConfig implements IConfigureNEI
     {
         this.registerRefineryRecipe(new PositionedStack(new ItemStack(GCItems.oilCanister, 1, 1), 2, 3), new PositionedStack(new ItemStack(GCItems.fuelCanister, 1, 1), 148, 3));
 
-        this.addRocketRecipes();
-        this.addBuggyRecipes();
+        //Handled by GalaxySpace
+        /*this.addRocketRecipes();
+        this.addBuggyRecipes();*/
         this.addCircuitFabricatorRecipes();
         this.addIngotCompressorRecipes();
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/recipe/RecipeManagerGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/recipe/RecipeManagerGC.java
@@ -97,7 +97,8 @@ public class RecipeManagerGC
 
         RecipeUtil.addRecipe(new ItemStack(GCItems.rocketEngine, 1, 1), new Object[] { "ZYZ", "ZWZ", "XVX", 'V', GCItems.oxygenVent, 'W', new ItemStack(GCItems.fuelCanister, 1, 1), 'X', GCItems.heavyPlatingTier1, 'Y', new ItemStack(Blocks.wool, 1, 4), 'Z', meteoricIronPlate });
 
-        HashMap<Integer, ItemStack> input = new HashMap<Integer, ItemStack>();
+        //Handled by GalaxySpace
+        /*HashMap<Integer, ItemStack> input = new HashMap<Integer, ItemStack>();
         input.put(1, new ItemStack(GCItems.partNoseCone));
         input.put(2, new ItemStack(GCItems.heavyPlatingTier1));
         input.put(3, new ItemStack(GCItems.heavyPlatingTier1));
@@ -223,7 +224,7 @@ public class RecipeManagerGC
         input2.put(17, new ItemStack(GCItems.partBuggy, 1, 2));
         input2.put(18, new ItemStack(GCItems.partBuggy, 1, 2));
         input2.put(19, new ItemStack(GCItems.partBuggy, 1, 2));
-        RecipeUtil.addBuggyBenchRecipe(new ItemStack(GCItems.buggy, 1, 3), input2);
+        RecipeUtil.addBuggyBenchRecipe(new ItemStack(GCItems.buggy, 1, 3), input2);*/
 
         aluminumIngots.addAll(OreDictionary.getOres("ingotAluminum"));
     	ArrayList<ItemStack> addedList = new ArrayList<ItemStack>();
@@ -371,7 +372,8 @@ public class RecipeManagerGC
 
         RecipeUtil.addRecipe(new ItemStack(GCBlocks.oxygenCollector, 1), new Object[] { "WWW", "YXZ", "UVU", 'U', "compressedAluminum", 'V', GCItems.oxygenConcentrator, 'W', "compressedSteel", 'X', new ItemStack(GCItems.canister, 1, 0), 'Y', GCItems.oxygenFan, 'Z', GCItems.oxygenVent });
 
-        RecipeUtil.addRecipe(new ItemStack(GCBlocks.nasaWorkbench, 1), new Object[] { "XZX", "UWU", "YVY", 'U', Blocks.lever, 'V', Blocks.redstone_torch, 'W', "waferAdvanced", 'X', "compressedSteel", 'Y', "compressedSteel", 'Z', Blocks.crafting_table });
+        //Handled by Galaxy Space
+        //RecipeUtil.addRecipe(new ItemStack(GCBlocks.nasaWorkbench, 1), new Object[] { "XZX", "UWU", "YVY", 'U', Blocks.lever, 'V', Blocks.redstone_torch, 'W', "waferAdvanced", 'X', "compressedSteel", 'Y', "compressedSteel", 'Z', Blocks.crafting_table });
 
         //RecipeUtil.addRecipe(new ItemStack(GCItems.oxTankHeavy, 1, GCItems.oxTankHeavy.getMaxDamage()), new Object[] { "ZZZ", "XXX", "YYY", 'X', new ItemStack(GCItems.canister, 1, 0), 'Y', "compressedSteel", 'Z', new ItemStack(Blocks.wool, 1, 14) });
 

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/AsteroidsModule.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/AsteroidsModule.java
@@ -161,7 +161,8 @@ public class AsteroidsModule implements IPlanetsModule
         GalaxyRegistry.registerPlanet(AsteroidsModule.planetAsteroids);
         GalacticraftRegistry.registerTeleportType(WorldProviderAsteroids.class, new TeleportTypeAsteroids());
 
-        HashMap<Integer, ItemStack> input = new HashMap<Integer, ItemStack>();
+        //Handled by Galaxy Space
+        /*HashMap<Integer, ItemStack> input = new HashMap<Integer, ItemStack>();
         input.put(1, new ItemStack(AsteroidsItems.heavyNoseCone));
         input.put(2, new ItemStack(AsteroidsItems.basicItem, 1, 0));
         input.put(3, new ItemStack(AsteroidsItems.basicItem, 1, 0));
@@ -242,7 +243,7 @@ public class AsteroidsModule implements IPlanetsModule
         input.put(8, new ItemStack(Blocks.chest));
         input.put(13, new ItemStack(AsteroidsItems.basicItem, 1, 8));
         input.put(14, new ItemStack(GCItems.flagPole));
-        GalacticraftRegistry.addAstroMinerRecipe(new NasaWorkbenchRecipe(new ItemStack(AsteroidsItems.astroMiner, 1, 0), input));
+        GalacticraftRegistry.addAstroMinerRecipe(new NasaWorkbenchRecipe(new ItemStack(AsteroidsItems.astroMiner, 1, 0), input));*/
     }
 
     @Override

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/AsteroidsModule.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/AsteroidsModule.java
@@ -140,8 +140,9 @@ public class AsteroidsModule implements IPlanetsModule
     public void init(FMLInitializationEvent event)
     {
         this.registerMicroBlocks();
-    	SchematicRegistry.registerSchematicRecipe(new SchematicTier3Rocket());
-    	SchematicRegistry.registerSchematicRecipe(new SchematicAstroMiner());
+    	//Handled by GalaxySpace
+        /*SchematicRegistry.registerSchematicRecipe(new SchematicTier3Rocket());
+    	SchematicRegistry.registerSchematicRecipe(new SchematicAstroMiner());*/
 
         GalacticraftCore.packetPipeline.addDiscriminator(7, PacketSimpleAsteroids.class);
 

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/AsteroidsModule.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/AsteroidsModule.java
@@ -140,9 +140,8 @@ public class AsteroidsModule implements IPlanetsModule
     public void init(FMLInitializationEvent event)
     {
         this.registerMicroBlocks();
-    	//Handled by GalaxySpace
-        /*SchematicRegistry.registerSchematicRecipe(new SchematicTier3Rocket());
-    	SchematicRegistry.registerSchematicRecipe(new SchematicAstroMiner());*/
+    	SchematicRegistry.registerSchematicRecipe(new SchematicTier3Rocket());
+    	SchematicRegistry.registerSchematicRecipe(new SchematicAstroMiner());
 
         GalacticraftCore.packetPipeline.addDiscriminator(7, PacketSimpleAsteroids.class);
 

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/nei/NEIGalacticraftAsteroidsConfig.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/nei/NEIGalacticraftAsteroidsConfig.java
@@ -27,11 +27,12 @@ public class NEIGalacticraftAsteroidsConfig implements IConfigureNEI
     @Override
     public void loadConfig()
     {
-        this.registerRecipes();
+        //Handled by GalaxySpace
+        /*this.registerRecipes();
         API.registerRecipeHandler(new RocketT3RecipeHandler());
         API.registerUsageHandler(new RocketT3RecipeHandler());
         API.registerRecipeHandler(new AstroMinerRecipeHandler());
-        API.registerUsageHandler(new AstroMinerRecipeHandler());
+        API.registerUsageHandler(new AstroMinerRecipeHandler());*/
         API.registerHighlightIdentifier(AsteroidBlocks.blockBasic, NEIGalacticraftMarsConfig.planetsHighlightHandler);
     }
 

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/MarsModule.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/MarsModule.java
@@ -119,9 +119,8 @@ public class MarsModule implements IPlanetsModule
     public void init(FMLInitializationEvent event)
     {
         this.registerMicroBlocks();
-        //Handled by GalaxySpace
-    	/*SchematicRegistry.registerSchematicRecipe(new SchematicTier2Rocket());
-        SchematicRegistry.registerSchematicRecipe(new SchematicCargoRocket());*/
+    	SchematicRegistry.registerSchematicRecipe(new SchematicTier2Rocket());
+        SchematicRegistry.registerSchematicRecipe(new SchematicCargoRocket());
 
         GalacticraftCore.packetPipeline.addDiscriminator(6, PacketSimpleMars.class);
 

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/MarsModule.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/MarsModule.java
@@ -119,8 +119,9 @@ public class MarsModule implements IPlanetsModule
     public void init(FMLInitializationEvent event)
     {
         this.registerMicroBlocks();
-    	SchematicRegistry.registerSchematicRecipe(new SchematicTier2Rocket());
-        SchematicRegistry.registerSchematicRecipe(new SchematicCargoRocket());
+        //Handled by GalaxySpace
+    	/*SchematicRegistry.registerSchematicRecipe(new SchematicTier2Rocket());
+        SchematicRegistry.registerSchematicRecipe(new SchematicCargoRocket());*/
 
         GalacticraftCore.packetPipeline.addDiscriminator(6, PacketSimpleMars.class);
 

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/nei/NEIGalacticraftMarsConfig.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/nei/NEIGalacticraftMarsConfig.java
@@ -29,10 +29,11 @@ public class NEIGalacticraftMarsConfig implements IConfigureNEI
     public void loadConfig()
     {
         this.registerRecipes();
-        API.registerRecipeHandler(new RocketT2RecipeHandler());
+        //Handled by GalaxySpace
+        /*API.registerRecipeHandler(new RocketT2RecipeHandler());
         API.registerUsageHandler(new RocketT2RecipeHandler());
         API.registerRecipeHandler(new CargoRocketRecipeHandler());
-        API.registerUsageHandler(new CargoRocketRecipeHandler());
+        API.registerUsageHandler(new CargoRocketRecipeHandler());*/
         API.registerRecipeHandler(new GasLiquefierRecipeHandler());
         API.registerUsageHandler(new GasLiquefierRecipeHandler());
         API.registerRecipeHandler(new MethaneSynthesizerRecipeHandler());
@@ -94,7 +95,8 @@ public class NEIGalacticraftMarsConfig implements IConfigureNEI
 
     public void registerRecipes()
     {
-        final int changeY = 15;
+        //Handled by GalaxySpace
+        /*final int changeY = 15;
 
         ArrayList<PositionedStack> input1 = new ArrayList<PositionedStack>();
 
@@ -197,7 +199,7 @@ public class NEIGalacticraftMarsConfig implements IConfigureNEI
         input2.add(new PositionedStack(new ItemStack(Blocks.chest), 90, -7 + changeY));
         input2.add(new PositionedStack(new ItemStack(Blocks.chest), 90 + 26, -7 + changeY));
         input2.add(new PositionedStack(new ItemStack(Blocks.chest), 90 + 52, -7 + changeY));
-        this.registerCargoBenchRecipe(input2, new PositionedStack(new ItemStack(MarsItems.spaceship, 1, 13), 139, 77 + changeY));
+        this.registerCargoBenchRecipe(input2, new PositionedStack(new ItemStack(MarsItems.spaceship, 1, 13), 139, 77 + changeY));*/
 
         this.registerLiquefierRecipe(new PositionedStack(new ItemStack(AsteroidsItems.methaneCanister, 1, 1), 2, 3), new PositionedStack(new ItemStack(GCItems.fuelCanister, 1, 1), 127, 3));
         this.registerLiquefierRecipe(new PositionedStack(new ItemStack(AsteroidsItems.atmosphericValve, 1, 0), 2, 3), new PositionedStack(new ItemStack(AsteroidsItems.canisterLN2, 1, 1), 127, 3));

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/recipe/RecipeManagerMars.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/recipe/RecipeManagerMars.java
@@ -104,7 +104,8 @@ public class RecipeManagerMars
         FurnaceRecipes.smelting().func_151394_a(new ItemStack(MarsBlocks.marsBlock, 1, 2), new ItemStack(MarsItems.marsItemBasic, 1, 2), 0.2F);
         FurnaceRecipes.smelting().func_151394_a(new ItemStack(MarsBlocks.marsBlock, 1, 3), new ItemStack(Items.iron_ingot), 0.2F);
 
-        // Schematic
+        //Handled by Galaxy Space
+        /*// Schematic
         HashMap<Integer, ItemStack> input = new HashMap<Integer, ItemStack>();
         input.put(1, new ItemStack(GCItems.partNoseCone));
         input.put(2, new ItemStack(MarsItems.marsItemBasic, 1, 3));
@@ -228,7 +229,7 @@ public class RecipeManagerMars
         input2.put(14, new ItemStack(Blocks.chest));
         input2.put(15, new ItemStack(Blocks.chest));
         input2.put(16, new ItemStack(Blocks.chest));
-        MarsUtil.adCargoRocketRecipe(new ItemStack(MarsItems.spaceship, 1, 13), input2);
+        MarsUtil.adCargoRocketRecipe(new ItemStack(MarsItems.spaceship, 1, 13), input2);*/
 
         RecipeUtil.addRecipe(new ItemStack(MarsBlocks.machine, 1, BlockMachineMars.LAUNCH_CONTROLLER_METADATA), new Object[] { "ZVZ", "YXY", "ZWZ", 'V', new ItemStack(GCItems.basicItem, 1, 19), 'W', new ItemStack(GCBlocks.aluminumWire, 1, 0), 'X', new ItemStack(GCItems.basicItem, 1, 14), 'Y', deshPlate, 'Z', deshIngot });
     }


### PR DESCRIPTION
The recipes and their NEI-representations of the T1-T3 Rockets, Cargo Rocket and Astro Miner will be handled by GalaxySpace. Previews can be found in [#galaxy-space-discussion](https://discordapp.com/channels/181078474394566657/739455313924587591/746075498131488939) on the GTNH Discord.