### PR TITLE
Gut IngotCompressorRecipeHandler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 def mcVersion = "1.7"
 def versionMajor = 3
 def versionMinor = 0
-def versionRev = "23-GTNH"
+def versionRev = "24-GTNH"
 
 def gsversion = "1.1.7b-GTNH"
 def gsjenkinsbuild = 62
 def micversion = "3.0.15-GTNH"
 def micjenkinsbuild = 2
-def gtversion = "5.09.34.03"
-def gtjenkinsbuild = 849
+def gtversion = "5.09.34.06"
+def gtjenkinsbuild = 895
 
 buildscript {
     repositories {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/nei/NEIGalacticraftConfig.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/nei/NEIGalacticraftConfig.java
@@ -65,10 +65,13 @@ public class NEIGalacticraftConfig implements IConfigureNEI
         API.registerUsageHandler(new RefineryRecipeHandler());
         API.registerRecipeHandler(new CircuitFabricatorRecipeHandler());
         API.registerUsageHandler(new CircuitFabricatorRecipeHandler());
+
+        /* Not used in GTNH
         API.registerRecipeHandler(new IngotCompressorRecipeHandler());
         API.registerUsageHandler(new IngotCompressorRecipeHandler());
         API.registerRecipeHandler(new ElectricIngotCompressorRecipeHandler());
-        API.registerUsageHandler(new ElectricIngotCompressorRecipeHandler());
+        API.registerUsageHandler(new ElectricIngotCompressorRecipeHandler()); */
+        
         API.registerHighlightIdentifier(GCBlocks.basicBlock, new GCNEIHighlightHandler());
         API.registerHighlightIdentifier(GCBlocks.blockMoon, new GCNEIHighlightHandler());
         API.registerHighlightIdentifier(GCBlocks.fakeBlock, new GCNEIHighlightHandler());

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/nei/NEIGalacticraftMarsConfig.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/nei/NEIGalacticraftMarsConfig.java
@@ -36,10 +36,13 @@ public class NEIGalacticraftMarsConfig implements IConfigureNEI
         //API.registerUsageHandler(new RocketT2RecipeHandler());
         API.registerRecipeHandler(new CargoRocketRecipeHandler());
         API.registerUsageHandler(new CargoRocketRecipeHandler());
+        
+        /* Not used in GTNH
         API.registerRecipeHandler(new GasLiquefierRecipeHandler());
         API.registerUsageHandler(new GasLiquefierRecipeHandler());
         API.registerRecipeHandler(new MethaneSynthesizerRecipeHandler());
-        API.registerUsageHandler(new MethaneSynthesizerRecipeHandler());
+        API.registerUsageHandler(new MethaneSynthesizerRecipeHandler()); */
+        
         API.registerHighlightIdentifier(MarsBlocks.marsBlock, planetsHighlightHandler);
     }
 


### PR DESCRIPTION
Gut IngotCompressorRecipeHandler since we're not using the GC compressor.  It contributed to NEI slowing down due to the large number of getBurnTime() calls.