### PR TITLE
Fix incorrect injection point for item gravity

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/mixins/minecraft/EntityItemMixin.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/mixins/minecraft/EntityItemMixin.java
@@ -9,7 +9,7 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 @Mixin(EntityItem.class)
 public abstract class EntityItemMixin {
 
-    @ModifyConstant(method = "onUpdate", constant = @Constant(doubleValue = 0.9800000190734863D), require = 1)
+    @ModifyConstant(method = "onUpdate", constant = @Constant(doubleValue = 0.03999999910593033D), require = 1)
     private double onOnUpdate(double value) {
         return WorldUtil.getItemGravity((EntityItem) (Object) this);
     }


### PR DESCRIPTION
Original injection point specification in MicdoodleCore: https://github.com/GTNewHorizons/MicdoodleCore/blob/86ee51959061a0041c6cfb692642cd44a13ac01d/src/main/java/micdoodle8/mods/miccore/MicdoodleTransformer.java#L829

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/9015