### PR TITLE
Use normal chest when ironchest not installed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1642484596
+//version: 1643020202
 /*
 DO NOT CHANGE THIS FILE!
 
@@ -32,16 +32,18 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.github.GTNewHorizons:ForgeGradle:1.2.5'
+        classpath 'com.github.GTNewHorizons:ForgeGradle:1.2.7'
     }
 }
 
 plugins {
     id 'idea'
+    id 'eclipse'
     id 'scala'
     id("org.ajoberstar.grgit") version("3.1.1")
     id("com.github.johnrengelman.shadow") version("4.0.4")
     id("com.palantir.git-version") version("0.12.3")
+    id('de.undercouch.download') version('4.1.2')
     id("maven-publish")
 }
 
@@ -172,6 +174,19 @@ else {
     archivesBaseName = modId
 }
 
+
+def arguments = []
+def jvmArguments = []
+
+if(usesMixins.toBoolean()) {
+    arguments += [
+            "--tweakClass org.spongepowered.asm.launch.MixinTweaker"
+    ]
+    jvmArguments += [
+            "-Dmixin.debug.countInjections=true", "-Dmixin.debug.verbose=true", "-Dmixin.debug.export=true"
+    ]
+}
+
 minecraft {
     version = minecraftVersion + "-" + forgeVersion + "-" + minecraftVersion
     runDir = "run"
@@ -190,6 +205,20 @@ minecraft {
         if(gradleTokenGroupName) {
             replace gradleTokenGroupName, modGroup
         }
+    }
+
+    clientIntellijRun {
+        args(arguments)
+        jvmArgs(jvmArguments)
+
+        if(developmentEnvironmentUserName) {
+            args("--username", developmentEnvironmentUserName)
+        }
+    }
+
+    serverIntellijRun {
+        args(arguments)
+        jvmArgs(jvmArguments)
     }
 }
 
@@ -322,15 +351,6 @@ afterEvaluate {
 }
 
 runClient {
-    def arguments = []
-
-    if(usesMixins.toBoolean()) {
-        arguments += [
-                "--mods=../build/libs/$modId-${version}.jar",
-                "--tweakClass org.spongepowered.asm.launch.MixinTweaker"
-        ]
-    }
-
     if(developmentEnvironmentUserName) {
         arguments += [
                 "--username",
@@ -339,19 +359,12 @@ runClient {
     }
 
     args(arguments)
+    jvmArgs(jvmArguments)
 }
 
 runServer {
-    def arguments = []
-
-    if (usesMixins.toBoolean()) {
-        arguments += [
-                "--mods=../build/libs/$modId-${version}.jar",
-                "--tweakClass org.spongepowered.asm.launch.MixinTweaker"
-        ]
-    }
-
     args(arguments)
+    jvmArgs(jvmArguments)
 }
 
 tasks.withType(JavaExec).configureEach {
@@ -494,11 +507,21 @@ artifacts {
     }
 }
 
+// The gradle metadata includes all of the additional deps that we disabled from POM generation (including forgeBin with no groupID), 
+// and isn't strictly needed with the POM so just disable it.
+tasks.withType(GenerateModuleMetadata) {
+    enabled = false
+}
+
+
 // publishing
 publishing {
     publications {
         maven(MavenPublication) {
-            artifact source: usesShadowedDependencies.toBoolean() ? shadowJar : jar, classifier: ""
+            from components.java
+            if(usesShadowedDependencies.toBoolean()) {
+                artifact source: shadowJar, classifier: ""
+            }
             if(!noPublishedSources) {
                 artifact source: sourcesJar, classifier: "src"
             }
@@ -511,6 +534,18 @@ publishing {
             artifactId = System.getenv("ARTIFACT_ID") ?: project.name
             // Using the identified version, not project.version as it has the prepended 1.7.10
             version = System.getenv("RELEASE_VERSION") ?: identifiedVersion
+            
+            // Remove all non GTNH deps here.
+            // Original intention was to remove an invalid forgeBin being generated without a groupId (mandatory), but
+            // it also removes all of the MC deps
+            pom.withXml {
+                Node pomNode = asNode()
+                pomNode.dependencies.'*'.findAll() {
+                    it.groupId.text() != 'com.github.GTNewHorizons'
+                }.each() {
+                    it.parent().remove(it)
+                }
+            }
         }
     }
 
@@ -579,6 +614,72 @@ static String getVersionHash(String buildScriptContent) {
 configure(updateBuildScript) {
     group = 'forgegradle'
     description = 'Updates the build script to the latest version'
+}
+
+// Deobfuscation
+
+def deobf(String sourceURL) {
+    try {
+        URL url = new URL(sourceURL)
+        String fileName = url.getFile()
+
+        //get rid of directories:
+        int lastSlash = fileName.lastIndexOf("/")
+        if(lastSlash > 0) {
+            fileName = fileName.substring(lastSlash + 1)
+        }
+        //get rid of extension:
+        if(fileName.endsWith(".jar")) {
+            fileName = fileName.substring(0, fileName.lastIndexOf("."))
+        }
+
+        String hostName = url.getHost()
+        if(hostName.startsWith("www.")) {
+            hostName = hostName.substring(4)
+        }
+        List parts = Arrays.asList(hostName.split("\\."))
+        Collections.reverse(parts)
+        hostName = String.join(".", parts)
+
+        return deobf(sourceURL, hostName + "/" + fileName)
+    } catch(Exception e) {
+        return deobf(sourceURL, "deobf/" + String.valueOf(sourceURL.hashCode()))
+    }
+}
+
+// The method above is to be prefered. Use this method if the filename is not at the end of the URL.
+def deobf(String sourceURL, String fileName) {
+    String cacheDir = System.getProperty("user.home") + "/.gradle/caches/"
+    String bon2Dir = cacheDir + "forge_gradle/deobf"
+    String bon2File  = bon2Dir + "/BON2-2.5.0.jar"
+    String obfFile = cacheDir + "modules-2/files-2.1/" + fileName + ".jar"
+    String deobfFile = cacheDir + "modules-2/files-2.1/" + fileName + "-deobf.jar"
+    
+    if(file(deobfFile).exists()) {
+        return files(deobfFile)
+    }
+
+    download {
+        src 'https://github.com/GTNewHorizons/BON2/releases/download/2.5.0/BON2-2.5.0.CUSTOM-all.jar'
+        dest bon2File
+        quiet true
+        overwrite false
+    }
+
+    download {
+        src sourceURL
+        dest obfFile
+        quiet true
+        overwrite false
+    }
+
+    exec {
+        commandLine 'java', '-jar', bon2File, '--inputJar', obfFile, '--outputJar', deobfFile, '--mcVer', '1.7.10', '--mappingsVer', 'stable_12', '--notch'
+        workingDir bon2Dir
+        standardOutput = new ByteArrayOutputStream()
+    }
+
+    return files(deobfFile)
 }
 
 // Helper methods

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,9 +1,7 @@
 dependencies {
-    compile("com.github.GTNewHorizons:GT5-Unofficial:5.09.40.17:dev")
-    compile("com.github.GTNewHorizons:TinkersConstruct:1.9.0.10-GTNH:dev")
-    compile("com.github.GTNewHorizons:ironchest:6.0.68:dev")
-    compile("com.github.GTNewHorizons:CodeChickenLib:1.1.5.1:dev")
-    compile("com.github.GTNewHorizons:NotEnoughItems:2.1.22-GTNH:dev")
+    compile("com.github.GTNewHorizons:GT5-Unofficial:5.09.40.25:dev")
+    compile("com.github.GTNewHorizons:TinkersConstruct:1.9.0.12-GTNH:dev")
+    compile("com.github.GTNewHorizons:NotEnoughItems:2.2.3-GTNH:dev")
     compile("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
 
     compileOnly("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-70-GTNH:api") {
@@ -27,4 +25,6 @@ dependencies {
     compileOnly("curse.maven:mekanism-268560:2475797") {
         transitive = false
     }
+
+    runtimeOnly("com.github.GTNewHorizons:ironchest:6.0.68:dev")
 }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/inventory/SlotBuggyBench.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/inventory/SlotBuggyBench.java
@@ -1,12 +1,12 @@
 package micdoodle8.mods.galacticraft.core.inventory;
 
 import cpw.mods.fml.common.registry.GameRegistry;
-import cpw.mods.ironchest.IronChest;
 import micdoodle8.mods.galacticraft.core.Constants;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.items.GCItems;
 import micdoodle8.mods.galacticraft.core.network.PacketSimple;
 import micdoodle8.mods.galacticraft.core.network.PacketSimple.EnumSimplePacket;
+import micdoodle8.mods.galacticraft.core.util.RecipeUtil;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.IInventory;
@@ -75,7 +75,7 @@ public class SlotBuggyBench extends Slot
         } else if(index >= 25 && index <= 34) {
             return itemStack.getItem() == GCItems.heavyPlatingTier1;
         } else if(index == 35) {
-            return itemStack.getItem() == Item.getItemFromBlock(IronChest.ironChestBlock) && (itemStack.getItemDamage() == 0 || itemStack.getItemDamage() == 1 || itemStack.getItemDamage() == 3);
+            return itemStack.getItem() == Item.getItemFromBlock(RecipeUtil.getChestBlock()) && (itemStack.getItemDamage() == 0 || itemStack.getItemDamage() == 1 || itemStack.getItemDamage() == 3);
         } else {
             return false;
         }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/nei/NEIGalacticraftConfig.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/nei/NEIGalacticraftConfig.java
@@ -3,7 +3,6 @@ package micdoodle8.mods.galacticraft.core.nei;
 import codechicken.nei.PositionedStack;
 import codechicken.nei.api.API;
 import codechicken.nei.api.IConfigureNEI;
-import cpw.mods.ironchest.IronChest;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.GT_ModHandler;
@@ -14,6 +13,7 @@ import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.blocks.GCBlocks;
 import micdoodle8.mods.galacticraft.core.items.GCItems;
 import micdoodle8.mods.galacticraft.core.util.ConfigManagerCore;
+import micdoodle8.mods.galacticraft.core.util.RecipeUtil;
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -193,13 +193,13 @@ public class NEIGalacticraftConfig implements IConfigureNEI
         input.put(34, new PositionedStack(new ItemStack(GCItems.heavyPlatingTier1), 80 - x, 91 - y));
         registerBuggyBenchRecipe(input, new PositionedStack(new ItemStack(GCItems.buggy), 143 - x, 64 - y));
         HashMap<Integer, PositionedStack> input2 = new HashMap<>(input);
-        input2.put(35, new PositionedStack(new ItemStack(IronChest.ironChestBlock, 1, 3), 107 - x, 64 - y));
+        input2.put(35, new PositionedStack(RecipeUtil.getChestItemStack(1, 3), 107 - x, 64 - y));
         registerBuggyBenchRecipe(input2, new PositionedStack(new ItemStack(GCItems.buggy, 1, 1), 143 - x, 64 - y));
         input2 = new HashMap<>(input);
-        input2.put(35, new PositionedStack(new ItemStack(IronChest.ironChestBlock), 107 - x, 64 - y));
+        input2.put(35, new PositionedStack(RecipeUtil.getChestItemStack(1, 0), 107 - x, 64 - y));
         registerBuggyBenchRecipe(input2, new PositionedStack(new ItemStack(GCItems.buggy, 1, 2), 143 - x, 64 - y));
         input2 = new HashMap<>(input);
-        input2.put(35, new PositionedStack(new ItemStack(IronChest.ironChestBlock, 1, 1), 107 - x, 64 - y));
+        input2.put(35, new PositionedStack(RecipeUtil.getChestItemStack(1, 1), 107 - x, 64 - y));
         registerBuggyBenchRecipe(input2, new PositionedStack(new ItemStack(GCItems.buggy, 1, 3), 143 - x, 64 - y));
     }
 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/recipe/RecipeManagerGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/recipe/RecipeManagerGC.java
@@ -1,7 +1,6 @@
 package micdoodle8.mods.galacticraft.core.recipe;
 
 import cpw.mods.fml.common.Loader;
-import cpw.mods.ironchest.IronChest;
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
@@ -31,7 +30,6 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.item.crafting.FurnaceRecipes;
-import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.ShapelessOreRecipe;
 
@@ -197,15 +195,15 @@ public class RecipeManagerGC
         RecipeUtil.addBuggyBenchRecipe(new ItemStack(GCItems.buggy, 1, 0), input2);
 
         input2 = new HashMap<Integer, ItemStack>(input);
-        input2.put(35, new ItemStack(IronChest.ironChestBlock, 1, 3));
+        input2.put(35, RecipeUtil.getChestItemStack(1, 3));
         RecipeUtil.addBuggyBenchRecipe(new ItemStack(GCItems.buggy, 1, 1), input2);
 
         input2 = new HashMap<Integer, ItemStack>(input);
-        input2.put(35, new ItemStack(IronChest.ironChestBlock));
+        input2.put(35, RecipeUtil.getChestItemStack(1, 0));
         RecipeUtil.addBuggyBenchRecipe(new ItemStack(GCItems.buggy, 1, 2), input2);
 
         input2 = new HashMap<Integer, ItemStack>(input);
-        input2.put(35, new ItemStack(IronChest.ironChestBlock, 1, 1));
+        input2.put(35, RecipeUtil.getChestItemStack(1, 1));
         RecipeUtil.addBuggyBenchRecipe(new ItemStack(GCItems.buggy, 1, 3), input2);
 
         aluminumIngots.addAll(OreDictionary.getOres("ingotAluminum"));

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/RecipeUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/RecipeUtil.java
@@ -1,11 +1,14 @@
 package micdoodle8.mods.galacticraft.core.util;
 
+import cpw.mods.fml.common.registry.GameRegistry;
 import ic2.api.item.IC2Items;
 import micdoodle8.mods.galacticraft.api.GalacticraftRegistry;
 import micdoodle8.mods.galacticraft.api.recipe.INasaWorkbenchRecipe;
 import micdoodle8.mods.galacticraft.core.inventory.InventoryBuggyBench;
 import micdoodle8.mods.galacticraft.core.inventory.InventoryRocketBench;
 import micdoodle8.mods.galacticraft.core.recipe.NasaWorkbenchRecipe;
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraftforge.oredict.OreDictionary;
@@ -74,4 +77,15 @@ public class RecipeUtil
 	{
 		return IC2Items.getItem(indentifier);
 	}
+
+    public static Block getChestBlock() {
+        Block block = GameRegistry.findBlock("IronChest", "BlockIronChest");
+        if (block == null)
+            block = Blocks.chest;
+        return block;
+    }
+    public static ItemStack getChestItemStack(int size, int meta) {
+        Block block = getChestBlock();
+        return new ItemStack(block, size, meta);
+    }
 }

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/AsteroidsModule.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/AsteroidsModule.java
@@ -5,7 +5,6 @@ import cpw.mods.fml.common.event.*;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.common.registry.LanguageRegistry;
 import cpw.mods.fml.relauncher.Side;
-import cpw.mods.ironchest.IronChest;
 import gregtech.api.util.GT_ModHandler;
 import micdoodle8.mods.galacticraft.api.GalacticraftRegistry;
 import micdoodle8.mods.galacticraft.api.galaxies.CelestialBody;
@@ -18,6 +17,7 @@ import micdoodle8.mods.galacticraft.core.command.CommandGCAstroMiner;
 import micdoodle8.mods.galacticraft.core.items.GCItems;
 import micdoodle8.mods.galacticraft.core.items.ItemCanisterGeneric;
 import micdoodle8.mods.galacticraft.core.recipe.NasaWorkbenchRecipe;
+import micdoodle8.mods.galacticraft.core.util.RecipeUtil;
 import micdoodle8.mods.galacticraft.planets.GuiIdsPlanets;
 import micdoodle8.mods.galacticraft.planets.IPlanetsModule;
 import micdoodle8.mods.galacticraft.planets.asteroids.blocks.AsteroidBlocks;
@@ -45,7 +45,6 @@ import micdoodle8.mods.galacticraft.planets.mars.MarsModule;
 import micdoodle8.mods.galacticraft.planets.mars.items.MarsItems;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
@@ -251,8 +250,8 @@ public class AsteroidsModule implements IPlanetsModule
         for(int i = 21; i <= 23; i++) {
             input.put(i, new ItemStack(GCItems.heavyPlatingTier1));
         }
-        input.put(24, new ItemStack(IronChest.ironChestBlock, 1, 1));
-        input.put(25, new ItemStack(IronChest.ironChestBlock, 1, 1));
+        input.put(24, RecipeUtil.getChestItemStack(1, 1));
+        input.put(25, RecipeUtil.getChestItemStack(1, 1));
         input.put(26, new ItemStack(AsteroidsItems.basicItem, 1, 8));
         input.put(27, new ItemStack(AsteroidBlocks.beamReceiver));
         input.put(28, GT_ModHandler.getModItem(Constants.MOD_ID_GREGTECH, "gt.metaitem.01", 1, 32603));

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/inventory/SlotSchematicAstroMiner.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/inventory/SlotSchematicAstroMiner.java
@@ -1,12 +1,12 @@
 package micdoodle8.mods.galacticraft.planets.asteroids.inventory;
 
 import cpw.mods.fml.common.registry.GameRegistry;
-import cpw.mods.ironchest.IronChest;
 import micdoodle8.mods.galacticraft.core.Constants;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.items.GCItems;
 import micdoodle8.mods.galacticraft.core.network.PacketSimple;
 import micdoodle8.mods.galacticraft.core.network.PacketSimple.EnumSimplePacket;
+import micdoodle8.mods.galacticraft.core.util.RecipeUtil;
 import micdoodle8.mods.galacticraft.planets.asteroids.blocks.AsteroidBlocks;
 import micdoodle8.mods.galacticraft.planets.asteroids.items.AsteroidsItems;
 import micdoodle8.mods.galacticraft.planets.mars.items.MarsItems;
@@ -75,7 +75,7 @@ public class SlotSchematicAstroMiner extends Slot
         } else if(index >= 21 && index <= 23) {
             return itemStack.getItem() == GCItems.heavyPlatingTier1;
         } else if(index == 24 || index == 25) {
-            return itemStack.getItem() == Item.getItemFromBlock(IronChest.ironChestBlock) && itemStack.getItemDamage() == 1;
+            return itemStack.getItem() == Item.getItemFromBlock(RecipeUtil.getChestBlock()) && itemStack.getItemDamage() == 1;
         } else if(index == 26) {
             return itemStack.getItem() == AsteroidsItems.basicItem && itemStack.getItemDamage() == 8;
         } else if(index == 27) {

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/nei/NEIGalacticraftAsteroidsConfig.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/nei/NEIGalacticraftAsteroidsConfig.java
@@ -3,23 +3,19 @@ package micdoodle8.mods.galacticraft.planets.asteroids.nei;
 import codechicken.nei.PositionedStack;
 import codechicken.nei.api.API;
 import codechicken.nei.api.IConfigureNEI;
-import cpw.mods.ironchest.IronChest;
 import gregtech.api.util.GT_ModHandler;
-import micdoodle8.mods.galacticraft.api.GalacticraftRegistry;
 import micdoodle8.mods.galacticraft.core.Constants;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.items.GCItems;
+import micdoodle8.mods.galacticraft.core.util.RecipeUtil;
 import micdoodle8.mods.galacticraft.planets.asteroids.blocks.AsteroidBlocks;
 import micdoodle8.mods.galacticraft.planets.asteroids.items.AsteroidsItems;
 import micdoodle8.mods.galacticraft.planets.mars.items.MarsItems;
 import micdoodle8.mods.galacticraft.planets.mars.nei.NEIGalacticraftMarsConfig;
-import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -156,9 +152,9 @@ public class NEIGalacticraftAsteroidsConfig implements IConfigureNEI
         input.add(new PositionedStack(new ItemStack(GCItems.heavyPlatingTier1), 116 - x, 37 - y));
         input.add(new PositionedStack(new ItemStack(GCItems.heavyPlatingTier1), 116 - x, 55 - y));
         input.add(new PositionedStack(new ItemStack(GCItems.heavyPlatingTier1), 116 - x, 73 - y));
-        input.add(new PositionedStack(new ItemStack(IronChest.ironChestBlock, 1, 1), 80 - x, 55 - y));
-        input.add(new PositionedStack(new ItemStack(IronChest.ironChestBlock, 1, 1), 98 - x, 55 - y));
-        input.add(new PositionedStack(new ItemStack(AsteroidsItems.basicItem, 1, 8), 44 - x, 73 - y));
+        input.add(new PositionedStack(RecipeUtil.getChestItemStack(1, 1), 80 - x, 55 - y));
+        input.add(new PositionedStack(RecipeUtil.getChestItemStack(1, 1), 98 - x, 55 - y));
+        input.add(new PositionedStack(RecipeUtil.getChestItemStack(1, 8), 44 - x, 73 - y));
         input.add(new PositionedStack(new ItemStack(AsteroidBlocks.beamReceiver), 62 - x, 73 - y));
         input.add(new PositionedStack(GT_ModHandler.getModItem(Constants.MOD_ID_GREGTECH, "gt.metaitem.01", 1, 32603), 80 - x, 73 - y));
         input.add(new PositionedStack(GT_ModHandler.getModItem(Constants.MOD_ID_GREGTECH, "gt.metaitem.01", 1, 32603), 98 - x, 73 - y));

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/nei/NEIGalacticraftAsteroidsConfig.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/nei/NEIGalacticraftAsteroidsConfig.java
@@ -154,7 +154,7 @@ public class NEIGalacticraftAsteroidsConfig implements IConfigureNEI
         input.add(new PositionedStack(new ItemStack(GCItems.heavyPlatingTier1), 116 - x, 73 - y));
         input.add(new PositionedStack(RecipeUtil.getChestItemStack(1, 1), 80 - x, 55 - y));
         input.add(new PositionedStack(RecipeUtil.getChestItemStack(1, 1), 98 - x, 55 - y));
-        input.add(new PositionedStack(RecipeUtil.getChestItemStack(1, 8), 44 - x, 73 - y));
+        input.add(new PositionedStack(new ItemStack(AsteroidsItems.basicItem, 1, 8), 44 - x, 73 - y));
         input.add(new PositionedStack(new ItemStack(AsteroidBlocks.beamReceiver), 62 - x, 73 - y));
         input.add(new PositionedStack(GT_ModHandler.getModItem(Constants.MOD_ID_GREGTECH, "gt.metaitem.01", 1, 32603), 80 - x, 73 - y));
         input.add(new PositionedStack(GT_ModHandler.getModItem(Constants.MOD_ID_GREGTECH, "gt.metaitem.01", 1, 32603), 98 - x, 73 - y));

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/inventory/SlotSchematicCargoRocket.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/inventory/SlotSchematicCargoRocket.java
@@ -1,12 +1,12 @@
 package micdoodle8.mods.galacticraft.planets.mars.inventory;
 
 import cpw.mods.fml.common.registry.GameRegistry;
-import cpw.mods.ironchest.IronChest;
 import micdoodle8.mods.galacticraft.core.Constants;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.items.GCItems;
 import micdoodle8.mods.galacticraft.core.network.PacketSimple;
 import micdoodle8.mods.galacticraft.core.network.PacketSimple.EnumSimplePacket;
+import micdoodle8.mods.galacticraft.core.util.RecipeUtil;
 import micdoodle8.mods.galacticraft.planets.mars.items.MarsItems;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -75,7 +75,7 @@ public class SlotSchematicCargoRocket extends Slot
         } else if(index >= 17 && index <= 20) {
             return itemStack.getItem() == GCItems.partFins;
         } else if(index == 21) {
-            return itemStack.getItem() == Item.getItemFromBlock(IronChest.ironChestBlock) && (itemStack.getItemDamage() == 0 || itemStack.getItemDamage() == 1 || itemStack.getItemDamage() == 3);
+            return itemStack.getItem() == Item.getItemFromBlock(RecipeUtil.getChestBlock()) && (itemStack.getItemDamage() == 0 || itemStack.getItemDamage() == 1 || itemStack.getItemDamage() == 3);
         } else {
             return false;
         }

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/nei/NEIGalacticraftMarsConfig.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/nei/NEIGalacticraftMarsConfig.java
@@ -3,15 +3,14 @@ package micdoodle8.mods.galacticraft.planets.mars.nei;
 import codechicken.nei.PositionedStack;
 import codechicken.nei.api.API;
 import codechicken.nei.api.IConfigureNEI;
-import cpw.mods.ironchest.IronChest;
 import gregtech.api.util.GT_ModHandler;
 import micdoodle8.mods.galacticraft.core.Constants;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.items.GCItems;
+import micdoodle8.mods.galacticraft.core.util.RecipeUtil;
 import micdoodle8.mods.galacticraft.planets.asteroids.items.AsteroidsItems;
 import micdoodle8.mods.galacticraft.planets.mars.blocks.MarsBlocks;
 import micdoodle8.mods.galacticraft.planets.mars.items.MarsItems;
-import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 
 import java.util.ArrayList;
@@ -180,13 +179,13 @@ public class NEIGalacticraftMarsConfig implements IConfigureNEI
         input.add(new PositionedStack(new ItemStack(GCItems.partFins), 26 - x, 109 - y));
         input.add(new PositionedStack(new ItemStack(GCItems.partFins), 80 - x, 109 - y));
         input2 = new ArrayList<>(input);
-        input2.add(new PositionedStack(new ItemStack(IronChest.ironChestBlock, 1, 3), 134 - x, 46 - y));
+        input2.add(new PositionedStack(RecipeUtil.getChestItemStack(1, 3), 134 - x, 46 - y));
         registerCargoBenchRecipe(input2, new PositionedStack(new ItemStack(MarsItems.spaceship, 1, 11), 134 - x, 73 - y));
         input2 = new ArrayList<>(input);
-        input2.add(new PositionedStack(new ItemStack(IronChest.ironChestBlock), 134 - x, 46 - y));
+        input2.add(new PositionedStack(RecipeUtil.getChestItemStack(1, 0), 134 - x, 46 - y));
         registerCargoBenchRecipe(input2, new PositionedStack(new ItemStack(MarsItems.spaceship, 1, 12), 134 - x, 73 - y));
         input2 = new ArrayList<>(input);
-        input2.add(new PositionedStack(new ItemStack(IronChest.ironChestBlock, 1, 1), 134 - x, 46 - y));
+        input2.add(new PositionedStack(RecipeUtil.getChestItemStack(1, 1), 134 - x, 46 - y));
         registerCargoBenchRecipe(input2, new PositionedStack(new ItemStack(MarsItems.spaceship, 1, 13), 134 - x, 73 - y));
 
         this.registerLiquefierRecipe(new PositionedStack(new ItemStack(AsteroidsItems.methaneCanister, 1, 1), 2, 3), new PositionedStack(new ItemStack(GCItems.fuelCanister, 1, 1), 127, 3));

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/recipe/RecipeManagerMars.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/recipe/RecipeManagerMars.java
@@ -1,6 +1,5 @@
 package micdoodle8.mods.galacticraft.planets.mars.recipe;
 
-import cpw.mods.ironchest.IronChest;
 import gregtech.api.util.GT_ModHandler;
 import micdoodle8.mods.galacticraft.core.Constants;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
@@ -195,13 +194,13 @@ public class RecipeManagerMars
         }
 
         input2 = new HashMap<Integer, ItemStack>(input);
-        input2.put(21, new ItemStack(IronChest.ironChestBlock, 1, 3));
+        input2.put(21, RecipeUtil.getChestItemStack(1, 3));
         MarsUtil.adCargoRocketRecipe(new ItemStack(MarsItems.spaceship, 1, 11), input2);
         input2 = new HashMap<Integer, ItemStack>(input);
-        input2.put(21, new ItemStack(IronChest.ironChestBlock));
+        input2.put(21, RecipeUtil.getChestItemStack(1, 0));
         MarsUtil.adCargoRocketRecipe(new ItemStack(MarsItems.spaceship, 1, 12), input2);
         input2 = new HashMap<Integer, ItemStack>(input);
-        input2.put(21, new ItemStack(IronChest.ironChestBlock, 1, 1));
+        input2.put(21, RecipeUtil.getChestItemStack(1, 1));
         MarsUtil.adCargoRocketRecipe(new ItemStack(MarsItems.spaceship, 1, 13), input2);
 
         RecipeUtil.addRecipe(new ItemStack(MarsBlocks.machine, 1, BlockMachineMars.LAUNCH_CONTROLLER_METADATA), new Object[] { "ZVZ", "YXY", "ZWZ", 'V', new ItemStack(GCItems.basicItem, 1, 19), 'W', new ItemStack(GCBlocks.aluminumWire, 1, 0), 'X', new ItemStack(GCItems.basicItem, 1, 14), 'Y', deshPlate, 'Z', deshIngot });


### PR DESCRIPTION
mostly useful in dev env, as pulling in ironchest is something we usually don't want

As a consequence, ironchest is now a runtimeOnly dependency