### PR TITLE
Fix crash when stopping server

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/WorldUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/WorldUtil.java
@@ -809,8 +809,12 @@ public class WorldUtil
         {
             for (Integer var1 : WorldUtil.registeredPlanets)
             {
-                DimensionManager.unregisterDimension(var1);
-                GCLog.info("Unregistered Dimension: " + var1);
+                try {
+                    DimensionManager.unregisterDimension(var1);
+                    GCLog.info("Unregistered Dimension: " + var1);
+                } catch (IllegalArgumentException e) {
+                    GCLog.info("Unregistered Dimension: " + var1 + " - already unregistered");
+                }
             }
 
             WorldUtil.registeredPlanets = null;


### PR DESCRIPTION
Fixed https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10046

Looking at the logs the crash looks like it was caused by `DimensionManager#unregisterDimension`
I'm not sure if there are any other problems

```log
[14:14:40] [Server thread/ERROR] [FML/]: Caught exception from GalacticraftCore
java.lang.IllegalArgumentException: Failed to unregister dimension for id 30; No provider registered
	at net.minecraftforge.common.DimensionManager.unregisterDimension(DimensionManager.java:134) ~[forge-1.7.10-10.13.4.1614-1.7.10-universal.jar:?]
	at micdoodle8.mods.galacticraft.core.util.WorldUtil.unregisterPlanets(WorldUtil.java:812) ~[Galacticraft-1.7.10-3.0.40-GTNH.jar:?]
	at micdoodle8.mods.galacticraft.core.GalacticraftCore.unregisterDims(GalacticraftCore.java:585) ~[Galacticraft-1.7.10-3.0.40-GTNH.jar:?]
```