### PR TITLE
Fix fuel loader destroying cells, add precise fuel amount to the GUI

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/gui/container/GuiFuelLoader.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/gui/container/GuiFuelLoader.java
@@ -28,6 +28,8 @@ public class GuiFuelLoader extends GuiContainerGC
     private GuiButton buttonLoadFuel;
     private GuiElementInfoRegion electricInfoRegion = new GuiElementInfoRegion((this.width - this.xSize) / 2 + 112, (this.height - this.ySize) / 2 + 65, 56, 9, new ArrayList<String>(), this.width, this.height, this);
 
+    private List<String> fuelTankDesc = new ArrayList<String>();
+
     public GuiFuelLoader(InventoryPlayer par1InventoryPlayer, TileEntityFuelLoader par2TileEntityAirDistributor)
     {
         super(new ContainerFuelLoader(par1InventoryPlayer, par2TileEntityAirDistributor));
@@ -51,9 +53,10 @@ public class GuiFuelLoader extends GuiContainerGC
     public void initGui()
     {
         super.initGui();
-        List<String> fuelTankDesc = new ArrayList<String>();
+        fuelTankDesc.clear();
         fuelTankDesc.add(GCCoreUtil.translate("gui.fuelTank.desc.2"));
         fuelTankDesc.add(GCCoreUtil.translate("gui.fuelTank.desc.3"));
+        fuelTankDesc.add("0.0/0.0 B");
         this.infoRegions.add(new GuiElementInfoRegion((this.width - this.xSize) / 2 + 7, (this.height - this.ySize) / 2 + 33, 16, 38, fuelTankDesc, this.width, this.height, this));
         List<String> batterySlotDesc = new ArrayList<String>();
         batterySlotDesc.add(GCCoreUtil.translate("gui.batterySlot.desc.0"));
@@ -113,6 +116,11 @@ public class GuiFuelLoader extends GuiContainerGC
         EnergyDisplayHelper.getEnergyDisplayTooltip(this.fuelLoader.getEnergyStoredGC(), this.fuelLoader.getMaxEnergyStoredGC(), electricityDesc);
 //		electricityDesc.add(EnumColor.YELLOW + GCCoreUtil.translate("gui.energyStorage.desc.1") + ((int) Math.floor(this.fuelLoader.getEnergyStoredGC()) + " / " + (int) Math.floor(this.fuelLoader.getMaxEnergyStoredGC())));
         this.electricInfoRegion.tooltipStrings = electricityDesc;
+
+        String fuelStr = String.format("%.1f/%.1f B",
+                this.fuelLoader.fuelTank.getFluidAmount() / 1000.0f,
+                this.fuelLoader.fuelTank.getCapacity() / 1000.0f);
+        fuelTankDesc.set(2, fuelStr);
 
         if (this.fuelLoader.getEnergyStoredGC() > 0)
         {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/gui/container/GuiRocketInventory.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/gui/container/GuiRocketInventory.java
@@ -61,11 +61,20 @@ public class GuiRocketInventory extends GuiContainerGC
 
         if (this.mc.thePlayer != null && this.mc.thePlayer.ridingEntity != null && this.mc.thePlayer.ridingEntity instanceof EntitySpaceshipBase)
         {
-            this.fontRendererObj.drawString(GCCoreUtil.translate("gui.message.fuel.name") + ":", 125, 15 + 3, 4210752);
-            final double percentage = ((EntitySpaceshipBase) this.mc.thePlayer.ridingEntity).getScaledFuelLevel(100);
+            this.fontRendererObj.drawString(GCCoreUtil.translate("gui.message.fuel.name") + ":", 125, 15, 4210752);
+            final EntitySpaceshipBase spaceship = ((EntitySpaceshipBase) this.mc.thePlayer.ridingEntity);
+            final double percentage = spaceship.getScaledFuelLevel(100);
             final String color = percentage > 80.0D ? EnumColor.BRIGHT_GREEN.getCode() : percentage > 40.0D ? EnumColor.ORANGE.getCode() : EnumColor.RED.getCode();
-            final String str = percentage + "% " + GCCoreUtil.translate("gui.message.full.name");
-            this.fontRendererObj.drawString(color + str, 117 - str.length() / 2, 20 + 8, 4210752);
+            //final String str = percentage + "% " + GCCoreUtil.translate("gui.message.full.name");
+            final String str1 = String.format("%.1f%% %s",
+                    percentage, GCCoreUtil.translate("gui.message.full.name")
+                    );
+            final String str2 = String.format("%.1f/%.1f B",
+                    spaceship.fuelTank.getFluidAmount() / 1000.0f,
+                    spaceship.fuelTank.getCapacity() / 1000.0f
+            );
+            this.fontRendererObj.drawString(color + str1, 117 - str1.length() / 2, 16 + 8, 4210752);
+            this.fontRendererObj.drawString(color + str2, 117 - str2.length() / 2, 16 + 16, 4210752);
         }
     }
 


### PR DESCRIPTION
A couple of QoL fixes for fuel handling in galacticraft:

 - Fix the fuel loader voiding cells when putting in fuel
 - At the same time, add support for large cells - tested locally with steel cells, it correctly empties them and even does so partially if the whole contents wouldn't fit
 - Adds a fuel amount in buckets (0.1B precision) to the GUIs of the fuel loader and rocket inventory to stop having to guess from the percentage