### PR TITLE
Fix inaccessible Landing Balloons

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/entities/EntityLandingBalloons.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/entities/EntityLandingBalloons.java
@@ -99,7 +99,9 @@ public class EntityLandingBalloons extends EntityLanderBase implements IIgnoreSh
             }
 
             return true;
-        } else if (this.riddenByEntity == null && this.groundHitCount >= 14 && var1 instanceof EntityPlayerMP) {
+        } else if (this.riddenByEntity == null
+                && (this.groundHitCount >= 14 || var1.isSneaking())
+                && var1 instanceof EntityPlayerMP) {
             MarsUtil.openParachestInventory((EntityPlayerMP) var1, this);
             return true;
         } else if (var1 instanceof EntityPlayerMP) {
@@ -116,30 +118,6 @@ public class EntityLandingBalloons extends EntityLanderBase implements IIgnoreSh
 
     @Override
     public boolean pressKey(int key) {
-        if (this.onGround) {
-            return false;
-        }
-
-        //        switch (key)
-        //        {
-        //            case 0: // Accelerate
-        //            {
-        //                this.rotationPitchSpeed -= 0.5F * TURN_FACTOR;
-        //                return true;
-        //            }
-        //            case 1: // Deccelerate
-        //            {
-        //                this.rotationPitchSpeed += 0.5F * TURN_FACTOR;
-        //                return true;
-        //            }
-        //            case 2: // Left
-        //                this.rotationYawSpeed -= 0.5F * TURN_FACTOR;
-        //                return true;
-        //            case 3: // Right
-        //                this.rotationYawSpeed += 0.5F * TURN_FACTOR;
-        //                return true;
-        //        }
-
         return false;
     }
 

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/entities/EntityLandingBalloons.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/entities/EntityLandingBalloons.java
@@ -99,9 +99,7 @@ public class EntityLandingBalloons extends EntityLanderBase implements IIgnoreSh
             }
 
             return true;
-        } else if (this.riddenByEntity == null
-                && (this.groundHitCount >= 14 || var1.isSneaking())
-                && var1 instanceof EntityPlayerMP) {
+        } else if (this.riddenByEntity == null && this.onGround && var1 instanceof EntityPlayerMP) {
             MarsUtil.openParachestInventory((EntityPlayerMP) var1, this);
             return true;
         } else if (var1 instanceof EntityPlayerMP) {


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/1967

To be able to open the Landing Balloon's inventory, the Balloon has to have hit the ground at least 14 times. This is done because earlier than that the Balloon is still above the ground most of the time so if the player jumps out they might to go back to not fall to their death. To do so, they must right-click the Balloon (like any other rideable entity), so opening the inventory in that case is not what the player wants. After 14 hits the Ballon is close to or on the ground so it's unlikely the player wants to get back in. In this case the inventory used to (and still does) open when the player right-clicks. If the player exits earlier, the 14 hits are not reached (idk why), so they cannot access the inventory. They don't get back in the Balloon either because that requires it to be in the air.
I changed the hit requirement to just check, if the Balloon is on the ground.