### PR TITLE
Move reset of client proxy into world unload

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/proxy/ClientProxyCore.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/proxy/ClientProxyCore.java
@@ -163,6 +163,7 @@ import net.minecraftforge.client.MinecraftForgeClient;
 import net.minecraftforge.client.event.RenderPlayerEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.EnumHelper;
+import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.IFluidBlock;
 import org.lwjgl.BufferUtils;
@@ -1155,6 +1156,11 @@ public class ClientProxyCore extends CommonProxyCore {
         final double var7 = 1 + (y + ClientProxyCore.offsetY) / ClientProxyCore.globalRadius;
         x += (x % 16 - 8) * var7 + 8;
         z += (z % 16 - 8) * var7 + 8;
+    }
+
+    @SubscribeEvent
+    public void onWorldUnloaded(WorldEvent.Unload event) {
+        reset();
     }
 
     @SubscribeEvent

--- a/src/main/java/micdoodle8/mods/galacticraft/core/tick/TickHandlerClient.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/tick/TickHandlerClient.java
@@ -62,7 +62,6 @@ import net.minecraft.client.entity.EntityClientPlayerMP;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiIngameMenu;
-import net.minecraft.client.gui.GuiMainMenu;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.client.renderer.OpenGlHelper;
@@ -413,10 +412,6 @@ public class TickHandlerClient {
                 if (MapUtil.resetClientFlag.getAndSet(false)) {
                     MapUtil.resetClientBody();
                 }
-            }
-
-            if (minecraft.currentScreen instanceof GuiMainMenu) {
-                ClientProxyCore.reset();
             }
 
             if (world != null


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11860
The bug is caused because `GuiMainMenu` is for vanilla only.