### PR TITLE
Fix backwards-compatibility with other Galacticraft addons (e. g. ExtraPlanets)

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/ConfigManagerCore.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/ConfigManagerCore.java
@@ -127,6 +127,9 @@ public class ConfigManagerCore {
     // KEYBOARD AND MOUSE
     public static float mapMouseScrollSensitivity;
     public static boolean invertMapMouseScroll;
+    
+    //Kept to ensure backwards-compatibility with certain Galacticraft addons
+    public static int keyOverrideFuelLevelI = 0;
 
     public static ArrayList<Object> clientSave = null;
 


### PR DESCRIPTION
This PR simply re-adds an otherwise unused field that is required by (non-GTNH-adapted) Galacticraft addons like the ExtraPlanets mod.