### PR TITLE
Register planet biomes on preinit

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,10 +1,10 @@
 dependencies {
-    implementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.25:dev')
-    implementation('com.github.GTNewHorizons:TinkersConstruct:1.11.5-GTNH:dev')
-    implementation('com.github.GTNewHorizons:NotEnoughItems:2.5.4-GTNH:dev')
+    implementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.73:dev')
+    implementation('com.github.GTNewHorizons:TinkersConstruct:1.11.11-GTNH:dev')
+    implementation('com.github.GTNewHorizons:NotEnoughItems:2.5.21-GTNH:dev')
     api('net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev')
 
-    compileOnly('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-310-GTNH:api')
+    compileOnly('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-327-GTNH:api')
     compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.39:api')
 
     compileOnly('curse.maven:cofh-lib-220333:2388748')
@@ -13,5 +13,5 @@ dependencies {
     compileOnly('curse.maven:SmartRender-229857:2248949')
     compileOnly('curse.maven:mekanism-268560:2475797')
 
-    runtimeOnly('com.github.GTNewHorizons:ironchest:6.0.74:dev')
+    runtimeOnly('com.github.GTNewHorizons:ironchest:6.0.75:dev')
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ channel = stable
 mappingsVersion = 12
 
 # Defines other MCP mappings for dependency deobfuscation.
-remoteMappings = https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
+remoteMappings = https\://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
 
 # Select a default username for testing your mod. You can always override this per-run by running
 # `./gradlew runClient --username=AnotherPlayer`, or configuring this command in your IDE.
@@ -60,6 +60,9 @@ gradleTokenModId =
 
 # [DEPRECATED] Mod name replacement token.
 gradleTokenModName =
+
+# [DEPRECATED] Mod Group replacement token.
+gradleTokenGroupName =
 
 # [DEPRECATED]
 # Multiple source files can be defined here by providing a comma-separated list: Class1.java,Class2.java,Class3.java
@@ -123,7 +126,7 @@ includeWellKnownRepositories = true
 usesMavenPublishing = true
 
 # Maven repository to publish the mod to.
-# mavenPublishUrl = https://nexus.gtnewhorizons.com/repository/releases/
+# mavenPublishUrl = https\://nexus.gtnewhorizons.com/repository/releases/
 
 # Publishing to Modrinth requires you to set the MODRINTH_TOKEN environment variable to your current Modrinth API token.
 #
@@ -187,5 +190,3 @@ customArchiveBaseName = Galacticraft
 # This is meant to be set in $HOME/.gradle/gradle.properties.
 # ideaCheckSpotlessOnBuild = true
 
-# Non-GTNH properties
-gradleTokenGroupName = 

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.8'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.14'
 }
 
 

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/GalacticraftPlanets.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/GalacticraftPlanets.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 import net.minecraft.block.Block;
+import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraftforge.common.config.ConfigElement;
 
 import cpw.mods.fml.client.config.IConfigElement;
@@ -24,10 +25,14 @@ import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import micdoodle8.mods.galacticraft.api.vector.Vector3;
 import micdoodle8.mods.galacticraft.core.Constants;
+import micdoodle8.mods.galacticraft.core.world.gen.BiomeGenBaseMoon;
+import micdoodle8.mods.galacticraft.core.world.gen.BiomeGenBaseOrbit;
 import micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule;
 import micdoodle8.mods.galacticraft.planets.asteroids.ConfigManagerAsteroids;
+import micdoodle8.mods.galacticraft.planets.asteroids.world.gen.BiomeGenBaseAsteroids;
 import micdoodle8.mods.galacticraft.planets.mars.ConfigManagerMars;
 import micdoodle8.mods.galacticraft.planets.mars.MarsModule;
+import micdoodle8.mods.galacticraft.planets.mars.world.gen.BiomeGenBaseMars;
 
 @Mod(
         modid = Constants.MOD_ID_PLANETS,
@@ -74,6 +79,13 @@ public class GalacticraftPlanets {
         GalacticraftPlanets.commonModules.put(GalacticraftPlanets.MODULE_KEY_MARS, new MarsModule());
         GalacticraftPlanets.commonModules.put(GalacticraftPlanets.MODULE_KEY_ASTEROIDS, new AsteroidsModule());
         GalacticraftPlanets.proxy.preInit(event);
+
+        registerBiomes();
+    }
+
+    private BiomeGenBase[] registerBiomes() {
+        return new BiomeGenBase[] { BiomeGenBaseMars.marsFlat, BiomeGenBaseAsteroids.asteroid,
+                BiomeGenBaseMoon.moonFlat, BiomeGenBaseOrbit.space };
     }
 
     @EventHandler

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/GalacticraftPlanets.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/GalacticraftPlanets.java
@@ -83,6 +83,10 @@ public class GalacticraftPlanets {
         registerBiomes();
     }
 
+    /**
+     * Reference static variables so that the biomes are registered on both the client and server instead of
+     * dynamically.
+     */
     private BiomeGenBase[] registerBiomes() {
         return new BiomeGenBase[] { BiomeGenBaseMars.marsFlat, BiomeGenBaseAsteroids.asteroid,
                 BiomeGenBaseMoon.moonFlat, BiomeGenBaseOrbit.space };


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12500#issuecomment-1962411271

Issue in Witchery's biome changing potion is due to GC's dynamic registered biomes. The server will always have them registered, but the clients wont until they go to the planet.