### PR TITLE
Don't let the rocket be launched again in the air

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/api/prefab/entity/EntityTieredRocket.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/prefab/entity/EntityTieredRocket.java
@@ -66,7 +66,7 @@ public abstract class EntityTieredRocket extends EntityAutoRocket
 
     public void igniteCheckingCooldown() {
         if (!this.worldObj.isRemote && this.launchCooldown <= 0
-                && this.launchPhase != EnumLaunchPhase.IGNITED.ordinal()) {
+                && this.launchPhase == EnumLaunchPhase.UNIGNITED.ordinal()) {
             this.setFrequency();
             this.initiatePlanetsPreGen(this.chunkCoordX, this.chunkCoordZ);
             this.ignite();


### PR DESCRIPTION
This fixes GTNewHorizons/GT-New-Horizons-Modpack#13213. This condition is called when the user presses spacebar while in the rocket. The previous condition only checked if the rocket wasn't ignited, but once the rocket is in the air its status is set to `EnumLaunchPhase.LAUNCHED` and launch can be triggered again by pressing spacebar again. This will check for the launchpad blocks below the rocket and find nothing since the first launch call already destroyed them, setting the launchpad field in `GCPlayerStats` to null.