### PR TITLE
Disable problematic glRotate for Angelica compat

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/proxy/ClientProxyCore.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/proxy/ClientProxyCore.java
@@ -1004,14 +1004,15 @@ public class ClientProxyCore extends CommonProxyCore {
                     eyeHeightChange * stats.gdir.getEyeVecY(),
                     eyeHeightChange * stats.gdir.getEyeVecZ());
 
-            if (stats.gravityTurnRate < 1.0F) {
-                GL11.glRotatef(
-                        90.0F * (stats.gravityTurnRatePrev
-                                + (stats.gravityTurnRate - stats.gravityTurnRatePrev) * partialTicks),
-                        stats.gravityTurnVecX,
-                        stats.gravityTurnVecY,
-                        stats.gravityTurnVecZ);
-            }
+            // Disabled for compat with Angelica, not sure what this actually did but doesn't seem to break anything?
+            // if (stats.gravityTurnRate < 1.0F) {
+            //     GL11.glRotatef(
+            //             90.0F * (stats.gravityTurnRatePrev
+            //                     + (stats.gravityTurnRate - stats.gravityTurnRatePrev) * partialTicks),
+            //             stats.gravityTurnVecX,
+            //             stats.gravityTurnVecY,
+            //             stats.gravityTurnVecZ);
+            // }
         }
 
         // omit this for interesting 3P views

--- a/src/main/java/micdoodle8/mods/galacticraft/core/proxy/ClientProxyCore.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/proxy/ClientProxyCore.java
@@ -1006,12 +1006,12 @@ public class ClientProxyCore extends CommonProxyCore {
 
             // Disabled for compat with Angelica, not sure what this actually did but doesn't seem to break anything?
             // if (stats.gravityTurnRate < 1.0F) {
-            //     GL11.glRotatef(
-            //             90.0F * (stats.gravityTurnRatePrev
-            //                     + (stats.gravityTurnRate - stats.gravityTurnRatePrev) * partialTicks),
-            //             stats.gravityTurnVecX,
-            //             stats.gravityTurnVecY,
-            //             stats.gravityTurnVecZ);
+            // GL11.glRotatef(
+            // 90.0F * (stats.gravityTurnRatePrev
+            // + (stats.gravityTurnRate - stats.gravityTurnRatePrev) * partialTicks),
+            // stats.gravityTurnVecX,
+            // stats.gravityTurnVecY,
+            // stats.gravityTurnVecZ);
             // }
         }
 


### PR DESCRIPTION
Fix for https://github.com/GTNewHorizons/Angelica/issues/379.

Disabling this section seems to fix the camera issues with space stations, and as far as I can tell doesn't break/change anything else. It doesn't seem to break anything without Angelica, and with Angelica it fixes the above issue and doesn't change anything else that I could find.

Would appreciate more testing as I'm not super familiar with later game space exploration content.