### PR TITLE
Remove GC Planets Checks

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,10 +1,12 @@
 dependencies {
-    implementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.161:dev')
-    implementation('com.github.GTNewHorizons:TinkersConstruct:1.11.15-GTNH:dev')
-    implementation('com.github.GTNewHorizons:NotEnoughItems:2.5.27-GTNH:dev')
+    implementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.48.37:dev') {
+        exclude group: 'com.github.GTNewHorizons', module: 'Galacticraft'
+    }
+    implementation('com.github.GTNewHorizons:TinkersConstruct:1.12.2-GTNH:dev')
+    implementation('com.github.GTNewHorizons:NotEnoughItems:2.6.5-GTNH:dev')
     api('net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev')
 
-    compileOnly('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-350-GTNH:api')
+    compileOnly('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-405-GTNH:api')
     compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.39:api')
 
     compileOnly('curse.maven:cofh-lib-220333:2388748')

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.21'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.23'
 }
 
 

--- a/src/main/java/micdoodle8/mods/galacticraft/api/recipe/RocketFuels.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/recipe/RocketFuels.java
@@ -92,7 +92,7 @@ public class RocketFuels {
         if (fluid instanceof FluidStack fluidStack) {
             return fluidStack.getFluid().getName();
         }
-        throw new IllegalArgumentException(fluid + " is not an instace of String, FLuid or FluidStack!");
+        throw new IllegalArgumentException(fluid + " is not an instace of String, Fluid or FluidStack!");
     }
 
     private RocketFuels() {}

--- a/src/main/java/micdoodle8/mods/galacticraft/core/GalacticraftCore.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/GalacticraftCore.java
@@ -179,7 +179,7 @@ public class GalacticraftCore {
     @Instance(Constants.MOD_ID_CORE)
     public static GalacticraftCore instance;
 
-    public static boolean isPlanetsLoaded;
+    public static boolean isPlanetsLoaded = true;
     public static boolean isGalaxySpaceLoaded;
     public static boolean isHeightConflictingModInstalled;
 
@@ -224,7 +224,6 @@ public class GalacticraftCore {
 
     @EventHandler
     public void preInit(FMLPreInitializationEvent event) {
-        isPlanetsLoaded = Loader.isModLoaded(Constants.MOD_ID_PLANETS);
         isGalaxySpaceLoaded = Loader.isModLoaded(Constants.MOD_ID_GALAXYSPACE);
         GCCoreUtil.nextID = 0;
 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/blocks/BlockMachineTiered.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/blocks/BlockMachineTiered.java
@@ -22,6 +22,7 @@ import micdoodle8.mods.galacticraft.core.items.ItemBlockDesc;
 import micdoodle8.mods.galacticraft.core.tile.TileEntityElectricFurnace;
 import micdoodle8.mods.galacticraft.core.tile.TileEntityEnergyStorageModule;
 import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
+import micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule;
 
 public class BlockMachineTiered extends BlockTileGC implements ItemBlockDesc.IBlockShiftDesc {
 
@@ -75,43 +76,16 @@ public class BlockMachineTiered extends BlockTileGC implements ItemBlockDesc.IBl
 
         this.iconElectricFurnace = iconRegister.registerIcon(GalacticraftCore.TEXTURE_PREFIX + "electricFurnace");
 
-        if (GalacticraftCore.isPlanetsLoaded) {
-            try {
-                final String prefix = (String) Class
-                        .forName("micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule")
-                        .getField("TEXTURE_PREFIX").get(null);
-                this.iconTier2 = iconRegister.registerIcon(prefix + "machine");
-                this.iconInputT2 = iconRegister.registerIcon(prefix + "machine_input");
-                this.iconOutputT2 = iconRegister.registerIcon(prefix + "machine_output");
-                this.iconMachineSideT2 = iconRegister.registerIcon(prefix + "machine_side");
-                this.iconEnergyStorageModuleT2 = new IIcon[17];
-                for (int i = 0; i < this.iconEnergyStorageModule.length; i++) {
-                    this.iconEnergyStorageModuleT2[i] = iconRegister.registerIcon(prefix + "energyStorageModule_" + i);
-                }
-                this.iconElectricFurnaceT2 = iconRegister.registerIcon(prefix + "electricFurnace");
-            } catch (final Exception e) {
-                e.printStackTrace();
-                this.iconTier2 = iconRegister.registerIcon("void");
-                this.iconInputT2 = iconRegister.registerIcon("void");
-                this.iconOutputT2 = iconRegister.registerIcon("void");
-                this.iconMachineSideT2 = iconRegister.registerIcon("void");
-                this.iconEnergyStorageModuleT2 = new IIcon[17];
-                for (int i = 0; i < this.iconEnergyStorageModule.length; i++) {
-                    this.iconEnergyStorageModuleT2[i] = iconRegister.registerIcon("void");
-                }
-                this.iconElectricFurnaceT2 = iconRegister.registerIcon("void");
-            }
-        } else {
-            this.iconTier2 = iconRegister.registerIcon("void");
-            this.iconInputT2 = iconRegister.registerIcon("void");
-            this.iconOutputT2 = iconRegister.registerIcon("void");
-            this.iconMachineSideT2 = iconRegister.registerIcon("void");
-            this.iconEnergyStorageModuleT2 = new IIcon[17];
-            for (int i = 0; i < this.iconEnergyStorageModule.length; i++) {
-                this.iconEnergyStorageModuleT2[i] = iconRegister.registerIcon("void");
-            }
-            this.iconElectricFurnaceT2 = iconRegister.registerIcon("void");
+        final String prefix = AsteroidsModule.TEXTURE_PREFIX;
+        this.iconTier2 = iconRegister.registerIcon(prefix + "machine");
+        this.iconInputT2 = iconRegister.registerIcon(prefix + "machine_input");
+        this.iconOutputT2 = iconRegister.registerIcon(prefix + "machine_output");
+        this.iconMachineSideT2 = iconRegister.registerIcon(prefix + "machine_side");
+        this.iconEnergyStorageModuleT2 = new IIcon[17];
+        for (int i = 0; i < this.iconEnergyStorageModule.length; i++) {
+            this.iconEnergyStorageModuleT2[i] = iconRegister.registerIcon(prefix + "energyStorageModule_" + i);
         }
+        this.iconElectricFurnaceT2 = iconRegister.registerIcon(prefix + "electricFurnace");
     }
 
     @Override
@@ -314,10 +288,8 @@ public class BlockMachineTiered extends BlockTileGC implements ItemBlockDesc.IBl
     public void getSubBlocks(Item par1, CreativeTabs par2CreativeTabs, List<ItemStack> par3List) {
         par3List.add(this.getEnergyStorageModule());
         par3List.add(this.getElectricFurnace());
-        if (GalacticraftCore.isPlanetsLoaded) {
-            par3List.add(this.getEnergyStorageCluster());
-            par3List.add(this.getElectricArcFurnace());
-        }
+        par3List.add(this.getEnergyStorageCluster());
+        par3List.add(this.getElectricArcFurnace());
     }
 
     @Override

--- a/src/main/java/micdoodle8/mods/galacticraft/core/blocks/BlockMulti.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/blocks/BlockMulti.java
@@ -29,6 +29,7 @@ import micdoodle8.mods.galacticraft.api.block.IPartialSealableBlock;
 import micdoodle8.mods.galacticraft.api.vector.BlockVec3;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.tile.TileEntityMulti;
+import micdoodle8.mods.galacticraft.planets.mars.MarsModule;
 
 public class BlockMulti extends BlockContainer implements IPartialSealableBlock, ITileEntityProvider {
 
@@ -60,20 +61,8 @@ public class BlockMulti extends BlockContainer implements IPartialSealableBlock,
         this.fakeIcons[0] = par1IconRegister.registerIcon(GalacticraftCore.TEXTURE_PREFIX + "launch_pad");
         this.fakeIcons[1] = par1IconRegister.registerIcon(GalacticraftCore.TEXTURE_PREFIX + "workbench_nasa_top");
         this.fakeIcons[2] = par1IconRegister.registerIcon(GalacticraftCore.TEXTURE_PREFIX + "solar_basic_0");
+        this.fakeIcons[3] = par1IconRegister.registerIcon(MarsModule.TEXTURE_PREFIX + "cryoDummy");
         this.fakeIcons[4] = par1IconRegister.registerIcon(GalacticraftCore.TEXTURE_PREFIX + "buggy_fueler_blank");
-
-        if (GalacticraftCore.isPlanetsLoaded) {
-            try {
-                final Class<?> c = Class.forName("micdoodle8.mods.galacticraft.planets.mars.MarsModule");
-                final String texturePrefix = (String) c.getField("TEXTURE_PREFIX").get(null);
-                this.fakeIcons[3] = par1IconRegister.registerIcon(texturePrefix + "cryoDummy");
-            } catch (final Exception e) {
-                this.fakeIcons[3] = this.fakeIcons[2];
-                e.printStackTrace();
-            }
-        } else {
-            this.fakeIcons[3] = this.fakeIcons[2];
-        }
     }
 
     @Override

--- a/src/main/java/micdoodle8/mods/galacticraft/core/blocks/BlockSlabGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/blocks/BlockSlabGC.java
@@ -15,6 +15,7 @@ import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
 
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
+import micdoodle8.mods.galacticraft.planets.mars.MarsModule;
 
 public class BlockSlabGC extends BlockSlab {
 
@@ -38,22 +39,8 @@ public class BlockSlabGC extends BlockSlab {
         this.textures[1] = par1IconRegister.registerIcon(GalacticraftCore.TEXTURE_PREFIX + "deco_aluminium_2");
         this.textures[2] = par1IconRegister.registerIcon(GalacticraftCore.TEXTURE_PREFIX_MOON + "bottom");
         this.textures[3] = par1IconRegister.registerIcon(GalacticraftCore.TEXTURE_PREFIX_MOON + "brick");
-
-        if (GalacticraftCore.isPlanetsLoaded) {
-            try {
-                final String prefix = (String) Class.forName("micdoodle8.mods.galacticraft.planets.mars.MarsModule")
-                        .getField("TEXTURE_PREFIX").get(null);
-                this.textures[4] = par1IconRegister.registerIcon(prefix + "cobblestone");
-                this.textures[5] = par1IconRegister.registerIcon(prefix + "brick");
-            } catch (final Exception e) {
-                e.printStackTrace();
-                this.textures[4] = this.textures[3];
-                this.textures[5] = this.textures[3];
-            }
-        } else {
-            this.textures[4] = this.textures[3];
-            this.textures[5] = this.textures[3];
-        }
+        this.textures[4] = par1IconRegister.registerIcon(MarsModule.TEXTURE_PREFIX + "cobblestone");
+        this.textures[5] = par1IconRegister.registerIcon(MarsModule.TEXTURE_PREFIX + "brick");
 
         this.tinSideIcon = new IIcon[1];
         this.tinSideIcon[0] = par1IconRegister.registerIcon(GalacticraftCore.TEXTURE_PREFIX + "deco_aluminium_1");
@@ -82,14 +69,7 @@ public class BlockSlabGC extends BlockSlab {
 
     @Override
     public void getSubBlocks(Item block, CreativeTabs creativeTabs, List<ItemStack> list) {
-        int max = 0;
-
-        if (GalacticraftCore.isPlanetsLoaded) {
-            max = 6; // Number of slab types with Planets loaded
-        } else {
-            max = 4; // Number of slab types with Planets not loaded
-        }
-        for (int i = 0; i < max; ++i) {
+        for (int i = 0; i < 6; ++i) {
             list.add(new ItemStack(block, 1, i));
         }
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/blocks/BlockStairsGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/blocks/BlockStairsGC.java
@@ -10,6 +10,7 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.util.IIcon;
 
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
+import micdoodle8.mods.galacticraft.planets.mars.MarsModule;
 
 public class BlockStairsGC extends BlockStairs {
 
@@ -68,22 +69,12 @@ public class BlockStairsGC extends BlockStairs {
         } else if (this.category == StairsCategoryGC.MOON_BRICKS) // Moon Dungeon Bricks
         {
             this.blockIcon = par1IconRegister.registerIcon(GalacticraftCore.TEXTURE_PREFIX_MOON + "brick");
-        }
-
-        if (GalacticraftCore.isPlanetsLoaded) {
-            try {
-                final String prefix = (String) Class.forName("micdoodle8.mods.galacticraft.planets.mars.MarsModule")
-                        .getField("TEXTURE_PREFIX").get(null);
-                if (this.category == StairsCategoryGC.MARS_COBBLESTONE) // Mars Cobblestone
-                {
-                    this.blockIcon = par1IconRegister.registerIcon(prefix + "cobblestone");
-                } else if (this.category == StairsCategoryGC.MARS_BRICKS) // Mars Dungeon Bricks
-                {
-                    this.blockIcon = par1IconRegister.registerIcon(prefix + "brick");
-                }
-            } catch (final Exception e) {
-                e.printStackTrace();
-            }
+        } else if (this.category == StairsCategoryGC.MARS_COBBLESTONE) // Mars Cobblestone
+        {
+            this.blockIcon = par1IconRegister.registerIcon(MarsModule.TEXTURE_PREFIX + "cobblestone");
+        } else if (this.category == StairsCategoryGC.MARS_BRICKS) // Mars Dungeon Bricks
+        {
+            this.blockIcon = par1IconRegister.registerIcon(MarsModule.TEXTURE_PREFIX + "brick");
         }
 
         this.tinSideIcon = new IIcon[2];

--- a/src/main/java/micdoodle8/mods/galacticraft/core/blocks/BlockWallGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/blocks/BlockWallGC.java
@@ -18,6 +18,7 @@ import net.minecraft.world.World;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
+import micdoodle8.mods.galacticraft.planets.mars.MarsModule;
 
 public class BlockWallGC extends BlockWall {
 
@@ -37,22 +38,8 @@ public class BlockWallGC extends BlockWall {
         this.wallBlockIcon[1] = par1IconRegister.registerIcon(GalacticraftCore.TEXTURE_PREFIX + "deco_aluminium_2");
         this.wallBlockIcon[2] = par1IconRegister.registerIcon(GalacticraftCore.TEXTURE_PREFIX_MOON + "bottom");
         this.wallBlockIcon[3] = par1IconRegister.registerIcon(GalacticraftCore.TEXTURE_PREFIX_MOON + "brick");
-
-        if (GalacticraftCore.isPlanetsLoaded) {
-            try {
-                final Class<?> c = Class.forName("micdoodle8.mods.galacticraft.planets.mars.MarsModule");
-                final String texturePrefix = (String) c.getField("TEXTURE_PREFIX").get(null);
-                this.wallBlockIcon[4] = par1IconRegister.registerIcon(texturePrefix + "cobblestone");
-                this.wallBlockIcon[5] = par1IconRegister.registerIcon(texturePrefix + "brick");
-            } catch (final Exception e) {
-                this.wallBlockIcon[4] = this.wallBlockIcon[3];
-                this.wallBlockIcon[5] = this.wallBlockIcon[3];
-                e.printStackTrace();
-            }
-        } else {
-            this.wallBlockIcon[4] = this.wallBlockIcon[3];
-            this.wallBlockIcon[5] = this.wallBlockIcon[3];
-        }
+        this.wallBlockIcon[4] = par1IconRegister.registerIcon(MarsModule.TEXTURE_PREFIX + "cobblestone");
+        this.wallBlockIcon[5] = par1IconRegister.registerIcon(MarsModule.TEXTURE_PREFIX + "brick");
 
         this.tinSideIcon = new IIcon[1];
         this.tinSideIcon[0] = par1IconRegister.registerIcon(GalacticraftCore.TEXTURE_PREFIX + "deco_aluminium_1");
@@ -162,14 +149,8 @@ public class BlockWallGC extends BlockWall {
     @SideOnly(Side.CLIENT)
     @Override
     public void getSubBlocks(Item par1, CreativeTabs par2CreativeTabs, List<ItemStack> par3List) {
-        if (GalacticraftCore.isPlanetsLoaded) {
-            for (int var4 = 0; var4 < 6; ++var4) {
-                par3List.add(new ItemStack(par1, 1, var4));
-            }
-        } else {
-            for (int var4 = 0; var4 < 4; ++var4) {
-                par3List.add(new ItemStack(par1, 1, var4));
-            }
+        for (int var4 = 0; var4 < 6; ++var4) {
+            par3List.add(new ItemStack(par1, 1, var4));
         }
     }
 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/entities/RenderPlayerBaseGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/entities/RenderPlayerBaseGC.java
@@ -20,13 +20,13 @@ import api.player.render.RenderPlayerBase;
 import cpw.mods.fml.client.FMLClientHandler;
 import micdoodle8.mods.galacticraft.api.entity.ICameraZoomEntity;
 import micdoodle8.mods.galacticraft.api.world.IGalacticraftWorldProvider;
-import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.blocks.GCBlocks;
 import micdoodle8.mods.galacticraft.core.client.model.ModelPlayerBaseGC;
 import micdoodle8.mods.galacticraft.core.client.render.entities.RenderPlayerGC.RotatePlayerEvent;
 import micdoodle8.mods.galacticraft.core.proxy.ClientProxyCore;
 import micdoodle8.mods.galacticraft.core.tile.TileEntityMulti;
 import micdoodle8.mods.galacticraft.core.wrappers.PlayerGearData;
+import micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule;
 import micdoodle8.mods.galacticraft.planets.mars.blocks.BlockMachineMars;
 import micdoodle8.mods.galacticraft.planets.mars.blocks.MarsBlocks;
 
@@ -34,8 +34,12 @@ public class RenderPlayerBaseGC extends RenderPlayerBase {
 
     public ModelPlayer modelThermalPadding;
     public ModelPlayer modelThermalPaddingHelmet;
-    private static ResourceLocation thermalPaddingTexture0;
-    private static ResourceLocation thermalPaddingTexture1;
+    private static final ResourceLocation thermalPaddingTexture0 = new ResourceLocation(
+            AsteroidsModule.ASSET_PREFIX,
+            "textures/misc/thermalPadding_0.png");
+    private static final ResourceLocation thermalPaddingTexture1 = new ResourceLocation(
+            AsteroidsModule.ASSET_PREFIX,
+            "textures/misc/thermalPadding_1.png");
 
     /**
      * This is used in place of RenderPlayerGC only if RenderPlayerAPI is installed It renders the thermal armor (also
@@ -47,18 +51,6 @@ public class RenderPlayerBaseGC extends RenderPlayerBase {
         super(renderPlayerAPI);
         this.modelThermalPadding = new ModelPlayer(0.25F);
         this.modelThermalPaddingHelmet = new ModelPlayer(0.9F);
-
-        if (GalacticraftCore.isPlanetsLoaded) {
-            try {
-                final String prefix = (String) Class
-                        .forName("micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule")
-                        .getField("ASSET_PREFIX").get(null);
-                thermalPaddingTexture0 = new ResourceLocation(prefix, "textures/misc/thermalPadding_0.png");
-                thermalPaddingTexture1 = new ResourceLocation(prefix, "textures/misc/thermalPadding_1.png");
-            } catch (final Exception e) {
-                e.printStackTrace();
-            }
-        }
     }
 
     @Override

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/entities/RenderPlayerGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/entities/RenderPlayerGC.java
@@ -21,12 +21,12 @@ import cpw.mods.fml.common.Loader;
 import micdoodle8.mods.galacticraft.api.entity.ICameraZoomEntity;
 import micdoodle8.mods.galacticraft.api.world.IGalacticraftWorldProvider;
 import micdoodle8.mods.galacticraft.api.world.IZeroGDimension;
-import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.blocks.GCBlocks;
 import micdoodle8.mods.galacticraft.core.client.model.ModelPlayerGC;
 import micdoodle8.mods.galacticraft.core.proxy.ClientProxyCore;
 import micdoodle8.mods.galacticraft.core.tile.TileEntityMulti;
 import micdoodle8.mods.galacticraft.core.wrappers.PlayerGearData;
+import micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule;
 import micdoodle8.mods.galacticraft.planets.mars.blocks.BlockMachineMars;
 import micdoodle8.mods.galacticraft.planets.mars.blocks.MarsBlocks;
 
@@ -43,14 +43,21 @@ public class RenderPlayerGC extends RenderPlayer {
 
     public static ModelBiped modelThermalPadding;
     public static ModelBiped modelThermalPaddingHelmet;
-    private static ResourceLocation thermalPaddingTexture0;
-    private static ResourceLocation thermalPaddingTexture1;
+    private static final ResourceLocation thermalPaddingTexture0;
+    private static final ResourceLocation thermalPaddingTexture1;
     public static boolean flagThermalOverride = false;
     private static Boolean isSmartRenderLoaded = null;
 
     static {
         modelThermalPadding = new ModelPlayerGC(0.25F);
         modelThermalPaddingHelmet = new ModelPlayerGC(0.9F);
+
+        thermalPaddingTexture0 = new ResourceLocation(
+                AsteroidsModule.ASSET_PREFIX,
+                "textures/misc/thermalPadding_0.png");
+        thermalPaddingTexture1 = new ResourceLocation(
+                AsteroidsModule.ASSET_PREFIX,
+                "textures/misc/thermalPadding_1.png");
     }
 
     public RenderPlayerGC() {
@@ -58,18 +65,6 @@ public class RenderPlayerGC extends RenderPlayer {
         this.modelBipedMain = (ModelPlayerGC) this.mainModel;
         this.modelArmorChestplate = new ModelPlayerGC(1.0F);
         this.modelArmor = new ModelPlayerGC(0.5F);
-
-        if (GalacticraftCore.isPlanetsLoaded) {
-            try {
-                final String prefix = (String) Class
-                        .forName("micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule")
-                        .getField("ASSET_PREFIX").get(null);
-                thermalPaddingTexture0 = new ResourceLocation(prefix, "textures/misc/thermalPadding_0.png");
-                thermalPaddingTexture1 = new ResourceLocation(prefix, "textures/misc/thermalPadding_1.png");
-            } catch (final Exception e) {
-                e.printStackTrace();
-            }
-        }
     }
 
     public static void renderModelS(RendererLivingEntity inst, EntityLivingBase par1EntityLivingBase, float par2,

--- a/src/main/java/micdoodle8/mods/galacticraft/core/entities/player/GCPlayerHandler.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/entities/player/GCPlayerHandler.java
@@ -1168,7 +1168,7 @@ public class GCPlayerHandler {
 
             if (player.worldObj.provider instanceof WorldProviderSpaceStation
                     || player.worldObj.provider instanceof IZeroGDimension
-                    || GalacticraftCore.isPlanetsLoaded && player.worldObj.provider instanceof WorldProviderAsteroids) {
+                    || player.worldObj.provider instanceof WorldProviderAsteroids) {
                 this.preventFlyingKicks(player);
             }
 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/entities/player/PlayerServer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/entities/player/PlayerServer.java
@@ -11,7 +11,6 @@ import net.minecraft.util.MathHelper;
 import net.minecraftforge.common.MinecraftForge;
 
 import micdoodle8.mods.galacticraft.api.entity.IIgnoreShift;
-import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.dimension.WorldProviderMoon;
 import micdoodle8.mods.galacticraft.core.entities.EntityCelestialFake;
 import micdoodle8.mods.galacticraft.core.event.EventWakePlayer;
@@ -72,31 +71,29 @@ public class PlayerServer implements IPlayerServer {
             return -1;
         }
 
-        if (GalacticraftCore.isPlanetsLoaded) {
-            if (par1DamageSource == DamageSource.outOfWorld) {
-                if (player.worldObj.provider instanceof WorldProviderAsteroids) {
-                    if (player.posY > -120D) {
-                        return -1;
-                    }
-                    if (player.posY > -180D) {
-                        par2 /= 2;
-                    }
+        if (par1DamageSource == DamageSource.outOfWorld) {
+            if (player.worldObj.provider instanceof WorldProviderAsteroids) {
+                if (player.posY > -120D) {
+                    return -1;
                 }
-            } else if (par1DamageSource == DamageSource.fall || par1DamageSource == DamageSourceGC.spaceshipCrash) {
-                int titaniumCount = 0;
-                if (player.inventory != null) {
-                    for (int i = 0; i < 4; i++) {
-                        final ItemStack armorPiece = player.getCurrentArmor(i);
-                        if (armorPiece != null && armorPiece.getItem() instanceof ItemArmorAsteroids) {
-                            titaniumCount++;
-                        }
-                    }
+                if (player.posY > -180D) {
+                    par2 /= 2;
                 }
-                if (titaniumCount == 4) {
-                    titaniumCount = 5;
-                }
-                par2 *= 1 - 0.15D * titaniumCount;
             }
+        } else if (par1DamageSource == DamageSource.fall || par1DamageSource == DamageSourceGC.spaceshipCrash) {
+            int titaniumCount = 0;
+            if (player.inventory != null) {
+                for (int i = 0; i < 4; i++) {
+                    final ItemStack armorPiece = player.getCurrentArmor(i);
+                    if (armorPiece != null && armorPiece.getItem() instanceof ItemArmorAsteroids) {
+                        titaniumCount++;
+                    }
+                }
+            }
+            if (titaniumCount == 4) {
+                titaniumCount = 5;
+            }
+            par2 *= 1 - 0.15D * titaniumCount;
         }
 
         return par2;
@@ -106,7 +103,7 @@ public class PlayerServer implements IPlayerServer {
     public void knockBack(EntityPlayerMP player, Entity p_70653_1_, float p_70653_2_, double impulseX,
             double impulseZ) {
         int deshCount = 0;
-        if (player.inventory != null && GalacticraftCore.isPlanetsLoaded) {
+        if (player.inventory != null) {
             for (int i = 0; i < 4; i++) {
                 final ItemStack armorPiece = player.getCurrentArmor(i);
                 if (armorPiece != null && armorPiece.getItem() instanceof ItemArmorMars) {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/event/EventHandlerGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/event/EventHandlerGC.java
@@ -235,9 +235,7 @@ public class EventHandlerGC {
                 && PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK.equals(event.action)
                 && !worldObj.isRemote
                 && !((IGalacticraftWorldProvider) worldObj.provider).hasBreathableAtmosphere()) {
-            if (GalacticraftCore.isPlanetsLoaded) {
-                GCPlayerStats.tryBedWarning((EntityPlayerMP) event.entityPlayer);
-            }
+            GCPlayerStats.tryBedWarning((EntityPlayerMP) event.entityPlayer);
 
             if (worldObj.provider instanceof WorldProviderOrbit) {
                 // On space stations simply block the bed activation => no explosion
@@ -317,9 +315,7 @@ public class EventHandlerGC {
         final EntityLivingBase entityLiving = event.entityLiving;
         if (entityLiving instanceof EntityPlayerMP) {
             GalacticraftCore.handler.onPlayerUpdate((EntityPlayerMP) entityLiving);
-            if (GalacticraftCore.isPlanetsLoaded) {
-                AsteroidsModule.playerHandler.onPlayerUpdate((EntityPlayerMP) entityLiving);
-            }
+            AsteroidsModule.playerHandler.onPlayerUpdate((EntityPlayerMP) entityLiving);
             return;
         }
 
@@ -775,10 +771,8 @@ public class EventHandlerGC {
             final EventWakePlayer event0 = new EventWakePlayer(player, c.posX, c.posY, c.posZ, true, true, false, true);
             MinecraftForge.EVENT_BUS.post(event0);
             player.wakeUpPlayer(true, true, false);
-            if (player.worldObj.isRemote && GalacticraftCore.isPlanetsLoaded) {
-                GalacticraftCore.packetPipeline.sendToServer(
-                        new PacketSimpleMars(PacketSimpleMars.EnumSimplePacketMars.S_WAKE_PLAYER, new Object[] {}));
-            }
+            GalacticraftCore.packetPipeline.sendToServer(
+                    new PacketSimpleMars(PacketSimpleMars.EnumSimplePacketMars.S_WAKE_PLAYER, new Object[] {}));
         }
     }
 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemSchematic.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemSchematic.java
@@ -15,7 +15,6 @@ import cpw.mods.fml.relauncher.SideOnly;
 import micdoodle8.mods.galacticraft.api.recipe.ISchematicItem;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.proxy.ClientProxyCore;
-import micdoodle8.mods.galacticraft.core.util.EnumColor;
 import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
 
 public class ItemSchematic extends Item implements ISchematicItem {
@@ -83,10 +82,6 @@ public class ItemSchematic extends Item implements ISchematicItem {
                     break;
                 case 1:
                     par3List.add(GCCoreUtil.translate("schematic.rocketT2.name"));
-
-                    if (!GalacticraftCore.isPlanetsLoaded) {
-                        par3List.add(EnumColor.DARK_AQUA + "\"Galacticraft: Planets\" Not Installed!");
-                    }
                     break;
             }
         }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/nei/NEIGalacticraftConfig.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/nei/NEIGalacticraftConfig.java
@@ -48,7 +48,7 @@ public class NEIGalacticraftConfig implements IConfigureNEI {
         for (final Block block : GCBlocks.hiddenBlocks) {
             API.hideItem(new ItemStack(block, 1, 0));
             if (block == GCBlocks.slabGCDouble) {
-                for (int j = 1; j < (GalacticraftCore.isPlanetsLoaded ? 6 : 4); j++) {
+                for (int j = 1; j < 6; j++) {
                     API.hideItem(new ItemStack(block, 1, j));
                 }
             }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/recipe/RecipeManagerGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/recipe/RecipeManagerGC.java
@@ -134,10 +134,9 @@ public class RecipeManagerGC {
         final Object meteoricIronPlate = ConfigManagerCore.recipesRequireGCAdvancedMetals
                 ? new ItemStack(GCItems.meteoricIronIngot, 1, 1)
                 : "compressedMeteoricIron";
-        final Object deshIngot = GalacticraftCore.isPlanetsLoaded
-                ? ConfigManagerCore.recipesRequireGCAdvancedMetals ? new ItemStack(MarsItems.marsItemBasic, 1, 2)
-                        : "ingotDesh"
-                : GCItems.heavyPlatingTier1;
+        final Object deshIngot = ConfigManagerCore.recipesRequireGCAdvancedMetals
+                ? new ItemStack(MarsItems.marsItemBasic, 1, 2)
+                : "ingotDesh";
 
         // RocketFuelRecipe.addFuel(GalacticraftCore.fluidFuel,1);
         FurnaceRecipes.smelting()
@@ -315,19 +314,17 @@ public class RecipeManagerGC {
                 new ItemStack(GCBlocks.machineTiered, 1, 4),
                 new Object[] { "XXX", "XZX", "WYW", 'W', "compressedAluminum", 'X', "compressedSteel", 'Y',
                         "waferBasic", 'Z', Blocks.furnace });
-        if (GalacticraftCore.isPlanetsLoaded) {
-            // Energy Storage Cluster:
-            RecipeUtil.addRecipe(
-                    new ItemStack(GCBlocks.machineTiered, 1, 8),
-                    new Object[] { "BSB", "SWS", "BSB", 'B', new ItemStack(GCBlocks.machineTiered, 1, 0), 'S',
-                            "compressedSteel", 'W', "waferAdvanced" });
-            // Electric Arc Furnace:
-            RecipeUtil.addRecipe(
-                    new ItemStack(GCBlocks.machineTiered, 1, 12),
-                    new Object[] { "XXX", "XZX", "WYW", 'W', meteoricIronIngot, 'X',
-                            new ItemStack(GCItems.heavyPlatingTier1), 'Y', "waferAdvanced", 'Z',
-                            new ItemStack(GCBlocks.machineTiered, 1, 4) });
-        }
+        // Energy Storage Cluster:
+        RecipeUtil.addRecipe(
+                new ItemStack(GCBlocks.machineTiered, 1, 8),
+                new Object[] { "BSB", "SWS", "BSB", 'B', new ItemStack(GCBlocks.machineTiered, 1, 0), 'S',
+                        "compressedSteel", 'W', "waferAdvanced" });
+        // Electric Arc Furnace:
+        RecipeUtil.addRecipe(
+                new ItemStack(GCBlocks.machineTiered, 1, 12),
+                new Object[] { "XXX", "XZX", "WYW", 'W', meteoricIronIngot, 'X',
+                        new ItemStack(GCItems.heavyPlatingTier1), 'Y', "waferAdvanced", 'Z',
+                        new ItemStack(GCBlocks.machineTiered, 1, 4) });
         RecipeUtil.addRecipe(
                 new ItemStack(GCBlocks.machineBase, 1, 12),
                 new Object[] { "WXW", "WYW", "WZW", 'W', "ingotAluminum", 'X', Blocks.anvil, 'Y', "ingotCopper", 'Z',

--- a/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityLandingPad.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityLandingPad.java
@@ -24,7 +24,6 @@ import micdoodle8.mods.galacticraft.api.prefab.entity.EntityTieredRocket;
 import micdoodle8.mods.galacticraft.api.tile.IFuelDock;
 import micdoodle8.mods.galacticraft.api.tile.ILandingPadAttachable;
 import micdoodle8.mods.galacticraft.api.vector.BlockVec3;
-import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.blocks.BlockMulti;
 import micdoodle8.mods.galacticraft.core.blocks.GCBlocks;
 import micdoodle8.mods.galacticraft.planets.mars.tile.TileEntityLaunchController;
@@ -181,7 +180,7 @@ public class TileEntityLandingPad extends TileEntityMulti
         if (tile instanceof ILandingPadAttachable && ((ILandingPadAttachable) tile)
                 .canAttachToLandingPad(this.worldObj, this.xCoord, this.yCoord, this.zCoord)) {
             connectedTiles.add((ILandingPadAttachable) tile);
-            if (GalacticraftCore.isPlanetsLoaded && tile instanceof TileEntityLaunchController) {
+            if (tile instanceof TileEntityLaunchController) {
                 ((TileEntityLaunchController) tile).setAttachedPad(this);
             }
         }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityOxygenStorageModule.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityOxygenStorageModule.java
@@ -17,7 +17,6 @@ import net.minecraftforge.fluids.IFluidHandler;
 
 import micdoodle8.mods.galacticraft.api.item.IItemOxygenSupply;
 import micdoodle8.mods.galacticraft.core.Constants;
-import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.blocks.BlockMachine2;
 import micdoodle8.mods.galacticraft.core.util.FluidUtil;
 import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
@@ -325,8 +324,7 @@ public class TileEntityOxygenStorageModule extends TileEntityOxygen implements I
 
     @Override
     public boolean canFill(ForgeDirection from, Fluid fluid) {
-        if (from.ordinal() == this.getBlockMetadata() - BlockMachine2.OXYGEN_STORAGE_MODULE_METADATA + 2
-                && GalacticraftCore.isPlanetsLoaded) {
+        if (from.ordinal() == this.getBlockMetadata() - BlockMachine2.OXYGEN_STORAGE_MODULE_METADATA + 2) {
             // Can fill with LOX only
             return fluid != null && fluid.getName().equals(AsteroidsModule.fluidLiquidOxygen.getName());
         }
@@ -352,7 +350,7 @@ public class TileEntityOxygenStorageModule extends TileEntityOxygen implements I
         final int metaside = this.getBlockMetadata() - BlockMachine2.OXYGEN_STORAGE_MODULE_METADATA + 2;
         final int side = from.ordinal();
 
-        if (metaside == side && GalacticraftCore.isPlanetsLoaded) {
+        if (metaside == side) {
             tankInfo = new FluidTankInfo[] { new FluidTankInfo(
                     new FluidStack(
                             AsteroidsModule.fluidLiquidOxygen,

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/ConfigManagerCore.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/ConfigManagerCore.java
@@ -25,7 +25,6 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import micdoodle8.mods.galacticraft.api.vector.BlockTuple;
 import micdoodle8.mods.galacticraft.core.Constants;
-import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.energy.EnergyConfigHandler;
 import micdoodle8.mods.galacticraft.core.recipe.RecipeManagerGC;
 import micdoodle8.mods.galacticraft.core.tick.TickHandlerClient;
@@ -513,9 +512,6 @@ public class ConfigManagerCore {
             prop.comment = "Set this to true for a challenging adventure where the player starts the game stranded in the Asteroids dimension with low resources (only effective if Galacticraft Planets installed).";
             prop.setLanguageKey("gc.configgui.asteroidsStart");
             challengeMode = prop.getBoolean(false);
-            if (!GalacticraftCore.isPlanetsLoaded) {
-                challengeMode = false;
-            }
             propOrder.add(prop.getName());
 
             prop = config.get(Constants.CONFIG_CATEGORY_GENERAL, "Adventure Game Mode Flags", 15);
@@ -737,12 +733,9 @@ public class ConfigManagerCore {
         }
 
         // This enables Endermen on Asteroids in Asteroids Challenge mode
-        if (GalacticraftCore.isPlanetsLoaded) {
-            ((BiomeGenBaseAsteroids) BiomeGenBaseAsteroids.asteroid)
-                    .resetMonsterListByMode(challengeMobDropsAndSpawning);
-            // TODO: could also increase mob spawn frequency in Hard Mode on various
-            // dimensions e.g. Moon and Mars?
-        }
+        ((BiomeGenBaseAsteroids) BiomeGenBaseAsteroids.asteroid).resetMonsterListByMode(challengeMobDropsAndSpawning);
+        // TODO: could also increase mob spawn frequency in Hard Mode on various
+        // dimensions e.g. Moon and Mars?
     }
 
     /**

--- a/src/main/java/micdoodle8/mods/galacticraft/core/world/gen/OreGenOtherMods.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/world/gen/OreGenOtherMods.java
@@ -12,7 +12,6 @@ import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import micdoodle8.mods.galacticraft.api.event.wgen.GCCoreEventPopulate;
 import micdoodle8.mods.galacticraft.api.vector.BlockTuple;
 import micdoodle8.mods.galacticraft.api.world.IGalacticraftWorldProvider;
-import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.blocks.GCBlocks;
 import micdoodle8.mods.galacticraft.core.dimension.WorldProviderMoon;
 import micdoodle8.mods.galacticraft.core.dimension.WorldProviderSpaceStation;
@@ -194,7 +193,7 @@ public class OreGenOtherMods {
             stoneBlock = GCBlocks.blockMoon;
             stoneMeta = 4;
             dimDetected = 1;
-        } else if (GalacticraftCore.isPlanetsLoaded && prov instanceof WorldProviderMars) {
+        } else if (prov instanceof WorldProviderMars) {
             stoneBlock = MarsBlocks.marsBlock;
             stoneMeta = 9;
             dimDetected = 2;


### PR DESCRIPTION
Due to GC Core and GC Planets being shipped in the same jar, GC Core doesn't need to check whether GC Planets is present or not anymore. Reflection to access GC Planets' classes is not needed anymore either.

Note: due to ***THE GREAT MERGENING***, GT now depends on GC. This cyclic dependency is prevented by adding `exclude group: 'com.github.GTNewHorizons', module: 'Galacticraft'`.