### PR TITLE
GCcore item and recipe cleanup for GTNH

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/entities/EntityEvolvedZombie.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/entities/EntityEvolvedZombie.java
@@ -23,7 +23,9 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeHooks;
 
+import cpw.mods.fml.common.Loader;
 import micdoodle8.mods.galacticraft.api.entity.IEntityBreathable;
+import micdoodle8.mods.galacticraft.core.Constants;
 import micdoodle8.mods.galacticraft.core.items.GCItems;
 import micdoodle8.mods.galacticraft.core.util.ConfigManagerCore;
 import micdoodle8.mods.galacticraft.core.util.WorldUtil;
@@ -154,7 +156,9 @@ public class EntityEvolvedZombie extends EntityZombie implements IEntityBreathab
         // Drop copper ingot as semi-rare drop if player hit and if dropping rotten
         // flesh (50% chance)
         if (p_70628_1_ && ConfigManagerCore.challengeMobDropsAndSpawning && j > 0 && this.rand.nextInt(6) == 0) {
-            this.entityDropItem(new ItemStack(GCItems.basicItem, 1, 3), 0.0F);
+            if (!Loader.isModLoaded(Constants.MOD_ID_NEW_HORIZONS_CORE_MOD)) {
+                this.entityDropItem(new ItemStack(GCItems.basicItem, 1, 3), 0.0F);
+            }
         }
     }
 }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/items/GCItems.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/items/GCItems.java
@@ -9,6 +9,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.util.EnumHelper;
 import net.minecraftforge.oredict.OreDictionary;
 
+import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.registry.GameRegistry;
 import micdoodle8.mods.galacticraft.core.Constants;
 import micdoodle8.mods.galacticraft.core.util.ConfigManagerCore;
@@ -227,9 +228,11 @@ public class GCItems {
         GCCoreUtil.registerGalacticraftItem("infiniteBattery", GCItems.infiniteBatery);
         GCCoreUtil.registerGalacticraftItem("infiniteOxygen", GCItems.oxygenCanisterInfinite);
         GCCoreUtil.registerGalacticraftItem("rawSilicon", GCItems.basicItem, 2);
-        GCCoreUtil.registerGalacticraftItem("ingotCopper", GCItems.basicItem, 3);
-        GCCoreUtil.registerGalacticraftItem("ingotTin", GCItems.basicItem, 4);
-        GCCoreUtil.registerGalacticraftItem("ingotAluminum", GCItems.basicItem, 5);
+        if (!Loader.isModLoaded(Constants.MOD_ID_NEW_HORIZONS_CORE_MOD)) {
+            GCCoreUtil.registerGalacticraftItem("ingotCopper", GCItems.basicItem, 3);
+            GCCoreUtil.registerGalacticraftItem("ingotTin", GCItems.basicItem, 4);
+            GCCoreUtil.registerGalacticraftItem("ingotAluminum", GCItems.basicItem, 5);
+        }
         GCCoreUtil.registerGalacticraftItem("compressedCopper", GCItems.basicItem, 6);
         GCCoreUtil.registerGalacticraftItem("compressedTin", GCItems.basicItem, 7);
         GCCoreUtil.registerGalacticraftItem("compressedAluminum", GCItems.basicItem, 8);
@@ -253,12 +256,17 @@ public class GCItems {
         for (int i = 0; i < ItemBasic.names.length; i++) {
             if (ItemBasic.names[i].contains("ingot") || ItemBasic.names[i].contains("compressed")
                     || ItemBasic.names[i].contains("wafer")) {
+                if (Loader.isModLoaded(Constants.MOD_ID_NEW_HORIZONS_CORE_MOD) && (2 < i) && (i < 6)) {
+                    continue;
+                }
                 OreDictionary.registerOre(ItemBasic.names[i], new ItemStack(GCItems.basicItem, 1, i));
             }
         }
 
         OreDictionary.registerOre("compressedMeteoricIron", new ItemStack(GCItems.meteoricIronIngot, 1, 1));
-        OreDictionary.registerOre("ingotMeteoricIron", new ItemStack(GCItems.meteoricIronIngot, 1, 0));
+        if (!Loader.isModLoaded(Constants.MOD_ID_NEW_HORIZONS_CORE_MOD)) {
+            OreDictionary.registerOre("ingotMeteoricIron", new ItemStack(GCItems.meteoricIronIngot, 1, 0));
+        }
         OreDictionary.registerOre(ConfigManagerCore.otherModsSilicon, new ItemStack(GCItems.basicItem, 1, 2));
     }
 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/nei/NEIGalacticraftConfig.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/nei/NEIGalacticraftConfig.java
@@ -17,6 +17,7 @@ import net.minecraftforge.oredict.ShapelessOreRecipe;
 import codechicken.nei.PositionedStack;
 import codechicken.nei.api.API;
 import codechicken.nei.api.IConfigureNEI;
+import cpw.mods.fml.common.Loader;
 import micdoodle8.mods.galacticraft.api.recipe.CompressorRecipes;
 import micdoodle8.mods.galacticraft.core.Constants;
 import micdoodle8.mods.galacticraft.core.blocks.GCBlocks;
@@ -46,6 +47,13 @@ public class NEIGalacticraftConfig implements IConfigureNEI {
                     API.hideItem(new ItemStack(block, 1, j));
                 }
             }
+        }
+
+        if (Loader.isModLoaded(Constants.MOD_ID_NEW_HORIZONS_CORE_MOD)) {
+            API.hideItem(new ItemStack(GCItems.basicItem, 1, 3));
+            API.hideItem(new ItemStack(GCItems.basicItem, 1, 4));
+            API.hideItem(new ItemStack(GCItems.basicItem, 1, 5));
+            API.hideItem(new ItemStack(GCItems.meteoricIronIngot, 1, 0));
         }
 
         // Handled by GalaxySpace

--- a/src/main/java/micdoodle8/mods/galacticraft/core/recipe/RecipeManagerGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/recipe/RecipeManagerGC.java
@@ -19,6 +19,7 @@ import micdoodle8.mods.galacticraft.api.entity.IFuelable;
 import micdoodle8.mods.galacticraft.api.recipe.CircuitFabricatorRecipes;
 import micdoodle8.mods.galacticraft.api.recipe.CompressorRecipes;
 import micdoodle8.mods.galacticraft.api.recipe.RocketFuels;
+import micdoodle8.mods.galacticraft.core.Constants;
 import micdoodle8.mods.galacticraft.core.blocks.BlockEnclosed.EnumEnclosedBlock;
 import micdoodle8.mods.galacticraft.core.blocks.GCBlocks;
 import micdoodle8.mods.galacticraft.core.entities.EntityBuggy;
@@ -40,16 +41,18 @@ public class RecipeManagerGC {
     public static ArrayList<ItemStack> aluminumIngots = new ArrayList<>();
 
     public static void loadRecipes() {
-        if (CompatibilityManager.isBCraftTransportLoaded()) {
-            RecipeManagerGC.addBuildCraftCraftingRecipes();
-        }
+        if (!Loader.isModLoaded(Constants.MOD_ID_NEW_HORIZONS_CORE_MOD)) {
+            if (CompatibilityManager.isBCraftTransportLoaded()) {
+                RecipeManagerGC.addBuildCraftCraftingRecipes();
+            }
 
-        if (CompatibilityManager.isIc2Loaded()) {
-            RecipeManagerGC.addIndustrialCraft2Recipes();
-        }
+            if (CompatibilityManager.isIc2Loaded()) {
+                RecipeManagerGC.addIndustrialCraft2Recipes();
+            }
 
-        if (CompatibilityManager.isAppEngLoaded()) {
-            RecipeManagerGC.addAppEngRecipes();
+            if (CompatibilityManager.isAppEngLoaded()) {
+                RecipeManagerGC.addAppEngRecipes();
+            }
         }
 
         RecipeManagerGC.addUniversalRecipes();
@@ -132,35 +135,41 @@ public class RecipeManagerGC {
                 : "ingotDesh";
 
         // RocketFuelRecipe.addFuel(GalacticraftCore.fluidFuel,1);
-        FurnaceRecipes.smelting()
-                .func_151394_a(new ItemStack(GCBlocks.basicBlock, 1, 5), new ItemStack(GCItems.basicItem, 1, 3), 0.5F);
-        FurnaceRecipes.smelting()
-                .func_151394_a(new ItemStack(GCBlocks.basicBlock, 1, 6), new ItemStack(GCItems.basicItem, 1, 4), 0.5F);
-        FurnaceRecipes.smelting()
-                .func_151394_a(new ItemStack(GCBlocks.basicBlock, 1, 7), new ItemStack(GCItems.basicItem, 1, 5), 0.5F);
+        if (!Loader.isModLoaded(Constants.MOD_ID_NEW_HORIZONS_CORE_MOD)) {
+            FurnaceRecipes.smelting().func_151394_a(
+                    new ItemStack(GCBlocks.basicBlock, 1, 5),
+                    new ItemStack(GCItems.basicItem, 1, 3),
+                    0.5F);
+            FurnaceRecipes.smelting().func_151394_a(
+                    new ItemStack(GCBlocks.basicBlock, 1, 6),
+                    new ItemStack(GCItems.basicItem, 1, 4),
+                    0.5F);
+            FurnaceRecipes.smelting().func_151394_a(
+                    new ItemStack(GCBlocks.basicBlock, 1, 7),
+                    new ItemStack(GCItems.basicItem, 1, 5),
+                    0.5F);
+            FurnaceRecipes.smelting()
+                    .func_151396_a(GCItems.meteoricIronRaw, new ItemStack(GCItems.meteoricIronIngot), 1.0F);
+            FurnaceRecipes.smelting().func_151394_a(
+                    new ItemStack(GCBlocks.blockMoon, 1, 0),
+                    new ItemStack(GCItems.basicItem, 1, 3),
+                    1.0F);
+            FurnaceRecipes.smelting().func_151394_a(
+                    new ItemStack(GCBlocks.blockMoon, 1, 1),
+                    new ItemStack(GCItems.basicItem, 1, 4),
+                    1.0F);
+            // Recycling: smelt tin/copper canisters back into ingots
+            FurnaceRecipes.smelting()
+                    .func_151394_a(new ItemStack(GCItems.canister, 1, 0), new ItemStack(GCItems.basicItem, 3, 4), 1.0F);
+            FurnaceRecipes.smelting()
+                    .func_151394_a(new ItemStack(GCItems.canister, 1, 1), new ItemStack(GCItems.basicItem, 3, 3), 1.0F);
+        }
         FurnaceRecipes.smelting().func_151394_a(
                 new ItemStack(GCItems.meteorChunk, 1, 0),
                 new ItemStack(GCItems.meteorChunk, 1, 1),
                 0.1F);
         FurnaceRecipes.smelting()
-                .func_151396_a(GCItems.meteoricIronRaw, new ItemStack(GCItems.meteoricIronIngot), 1.0F);
-        FurnaceRecipes.smelting()
-                .func_151394_a(new ItemStack(GCBlocks.blockMoon, 1, 0), new ItemStack(GCItems.basicItem, 1, 3), 1.0F);
-        FurnaceRecipes.smelting()
-                .func_151394_a(new ItemStack(GCBlocks.blockMoon, 1, 1), new ItemStack(GCItems.basicItem, 1, 4), 1.0F);
-        FurnaceRecipes.smelting()
                 .func_151394_a(new ItemStack(GCBlocks.blockMoon, 1, 2), new ItemStack(GCItems.cheeseCurd), 1.0F);
-        // Recycling: smelt tin/copper canisters back into ingots
-        FurnaceRecipes.smelting()
-                .func_151394_a(new ItemStack(GCItems.canister, 1, 0), new ItemStack(GCItems.basicItem, 3, 4), 1.0F);
-        FurnaceRecipes.smelting()
-                .func_151394_a(new ItemStack(GCItems.canister, 1, 1), new ItemStack(GCItems.basicItem, 3, 3), 1.0F);
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.rocketEngine, 1, 1),
-                new Object[] { "ZYZ", "ZWZ", "XVX", 'V', GCItems.oxygenVent, 'W',
-                        new ItemStack(GCItems.fuelCanister, 1, 1), 'X', GCItems.heavyPlatingTier1, 'Y',
-                        new ItemStack(Blocks.wool, 1, 4), 'Z', meteoricIronPlate });
 
         aluminumIngots.addAll(OreDictionary.getOres("ingotAluminum"));
         final ArrayList<ItemStack> addedList = new ArrayList<>();
@@ -192,90 +201,426 @@ public class RecipeManagerGC {
             aluminumIngots.addAll(addedList);
         }
 
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.aluminumWire, 6),
-                new Object[] { "WWW", "CCC", "WWW", 'W', Blocks.wool, 'C', "ingotAluminum" });
+        if (!Loader.isModLoaded(Constants.MOD_ID_NEW_HORIZONS_CORE_MOD)) {
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.aluminumWire, 6),
+                    new Object[] { "WWW", "CCC", "WWW", 'W', Blocks.wool, 'C', "ingotAluminum" });
 
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.aluminumWire, 1, 1),
-                new Object[] { "X", "Y", "Z", 'X', Blocks.wool, 'Y', new ItemStack(GCBlocks.aluminumWire, 1), 'Z',
-                        "ingotAluminum" });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.aluminumWire, 1, 1),
+                    new Object[] { "X", "Y", "Z", 'X', Blocks.wool, 'Y', new ItemStack(GCBlocks.aluminumWire, 1), 'Z',
+                            "ingotAluminum" });
 
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.aluminumWire, 1, 1),
-                new Object[] { "Z", "Y", "X", 'X', Blocks.wool, 'Y', new ItemStack(GCBlocks.aluminumWire, 1), 'Z',
-                        "ingotAluminum" });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.aluminumWire, 1, 1),
+                    new Object[] { "Z", "Y", "X", 'X', Blocks.wool, 'Y', new ItemStack(GCBlocks.aluminumWire, 1), 'Z',
+                            "ingotAluminum" });
 
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.machineBase, 1, 0),
-                new Object[] { "WWW", "XZX", "XYX", 'W', "ingotCopper", 'X', Items.iron_ingot, 'Y',
-                        new ItemStack(GCBlocks.aluminumWire, 1, 0), 'Z', Blocks.furnace });
-        // Energy Storage Module:
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.machineTiered, 1, 0),
-                new Object[] { "SSS", "BBB", "SSS", 'B',
-                        new ItemStack(GCItems.battery, 1, GCItems.battery.getMaxDamage()), 'S', "compressedSteel" });
-        // Electric Furnace:
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.machineTiered, 1, 4),
-                new Object[] { "XXX", "XZX", "WYW", 'W', "compressedAluminum", 'X', "compressedSteel", 'Y',
-                        "waferBasic", 'Z', Blocks.furnace });
-        // Energy Storage Cluster:
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.machineTiered, 1, 8),
-                new Object[] { "BSB", "SWS", "BSB", 'B', new ItemStack(GCBlocks.machineTiered, 1, 0), 'S',
-                        "compressedSteel", 'W', "waferAdvanced" });
-        // Electric Arc Furnace:
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.machineTiered, 1, 12),
-                new Object[] { "XXX", "XZX", "WYW", 'W', meteoricIronIngot, 'X',
-                        new ItemStack(GCItems.heavyPlatingTier1), 'Y', "waferAdvanced", 'Z',
-                        new ItemStack(GCBlocks.machineTiered, 1, 4) });
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.machineBase, 1, 12),
-                new Object[] { "WXW", "WYW", "WZW", 'W', "ingotAluminum", 'X', Blocks.anvil, 'Y', "ingotCopper", 'Z',
-                        "waferBasic" });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.machineBase, 1, 0),
+                    new Object[] { "WWW", "XZX", "XYX", 'W', "ingotCopper", 'X', Items.iron_ingot, 'Y',
+                            new ItemStack(GCBlocks.aluminumWire, 1, 0), 'Z', Blocks.furnace });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.machineBase, 1, 12),
+                    new Object[] { "WXW", "WYW", "WZW", 'W', "ingotAluminum", 'X', Blocks.anvil, 'Y', "ingotCopper",
+                            'Z', "waferBasic" });
 
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.machineBase2, 1, 0),
-                new Object[] { "WXW", "WYW", "VZV", 'V', new ItemStack(GCBlocks.aluminumWire), 'W', "compressedSteel",
-                        'X', Blocks.anvil, 'Y', "compressedBronze", 'Z', "waferAdvanced" });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.machineBase2, 1, 0),
+                    new Object[] { "WXW", "WYW", "VZV", 'V', new ItemStack(GCBlocks.aluminumWire), 'W',
+                            "compressedSteel", 'X', Blocks.anvil, 'Y', "compressedBronze", 'Z', "waferAdvanced" });
 
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.machineBase2, 1, 4),
-                new Object[] { "WXW", "UYU", "VZV", 'U', Blocks.stone_button, 'V', new ItemStack(GCBlocks.aluminumWire),
-                        'W', "ingotAluminum", 'X', Blocks.lever, 'Y', Blocks.furnace, 'Z', Blocks.redstone_torch });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.machineBase2, 1, 4),
+                    new Object[] { "WXW", "UYU", "VZV", 'U', Blocks.stone_button, 'V',
+                            new ItemStack(GCBlocks.aluminumWire), 'W', "ingotAluminum", 'X', Blocks.lever, 'Y',
+                            Blocks.furnace, 'Z', Blocks.redstone_torch });
 
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.machineBase2, 1, 8),
-                new Object[] { "SSS", "BBB", "SSS", 'B',
-                        new ItemStack(GCItems.oxTankHeavy, 1, GCItems.oxTankHeavy.getMaxDamage()), 'S',
-                        "compressedSteel" });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.machineBase2, 1, 8),
+                    new Object[] { "SSS", "BBB", "SSS", 'B',
+                            new ItemStack(GCItems.oxTankHeavy, 1, GCItems.oxTankHeavy.getMaxDamage()), 'S',
+                            "compressedSteel" });
+            // Energy Storage Module:
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.machineTiered, 1, 0),
+                    new Object[] { "SSS", "BBB", "SSS", 'B',
+                            new ItemStack(GCItems.battery, 1, GCItems.battery.getMaxDamage()), 'S',
+                            "compressedSteel" });
+            // Electric Furnace:
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.machineTiered, 1, 4),
+                    new Object[] { "XXX", "XZX", "WYW", 'W', "compressedAluminum", 'X', "compressedSteel", 'Y',
+                            "waferBasic", 'Z', Blocks.furnace });
+            // Energy Storage Cluster:
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.machineTiered, 1, 8),
+                    new Object[] { "BSB", "SWS", "BSB", 'B', new ItemStack(GCBlocks.machineTiered, 1, 0), 'S',
+                            "compressedSteel", 'W', "waferAdvanced" });
+            // Electric Arc Furnace:
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.machineTiered, 1, 12),
+                    new Object[] { "XXX", "XZX", "WYW", 'W', meteoricIronIngot, 'X',
+                            new ItemStack(GCItems.heavyPlatingTier1), 'Y', "waferAdvanced", 'Z',
+                            new ItemStack(GCBlocks.machineTiered, 1, 4) });
 
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.battery, 1, 100),
-                new Object[] { " T ", "TRT", "TCT", 'T', "compressedTin", 'R', Items.redstone, 'C', Items.coal });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.battery, 1, 100),
+                    new Object[] { " T ", "TRT", "TCT", 'T', "compressedTin", 'R', Items.redstone, 'C', Items.coal });
 
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.rocketEngine, 1),
-                new Object[] { " YV", "XWX", "XZX", 'V', Blocks.stone_button, 'W',
-                        new ItemStack(GCItems.canister, 1, 0), 'X', GCItems.heavyPlatingTier1, 'Y',
-                        Items.flint_and_steel, 'Z', GCItems.oxygenVent });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.rocketEngine, 1),
+                    new Object[] { " YV", "XWX", "XZX", 'V', Blocks.stone_button, 'W',
+                            new ItemStack(GCItems.canister, 1, 0), 'X', GCItems.heavyPlatingTier1, 'Y',
+                            Items.flint_and_steel, 'Z', GCItems.oxygenVent });
 
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.rocketEngine, 1),
-                new Object[] { "VY ", "XWX", "XZX", 'V', Blocks.stone_button, 'W',
-                        new ItemStack(GCItems.canister, 1, 0), 'X', GCItems.heavyPlatingTier1, 'Y',
-                        Items.flint_and_steel, 'Z', GCItems.oxygenVent });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.rocketEngine, 1),
+                    new Object[] { "VY ", "XWX", "XZX", 'V', Blocks.stone_button, 'W',
+                            new ItemStack(GCItems.canister, 1, 0), 'X', GCItems.heavyPlatingTier1, 'Y',
+                            Items.flint_and_steel, 'Z', GCItems.oxygenVent });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.rocketEngine, 1, 1),
+                    new Object[] { "ZYZ", "ZWZ", "XVX", 'V', GCItems.oxygenVent, 'W',
+                            new ItemStack(GCItems.fuelCanister, 1, 1), 'X', GCItems.heavyPlatingTier1, 'Y',
+                            new ItemStack(Blocks.wool, 1, 4), 'Z', meteoricIronPlate });
 
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.partNoseCone, 1),
-                new Object[] { " Y ", " X ", "X X", 'X', GCItems.heavyPlatingTier1, 'Y', Blocks.redstone_torch });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.partNoseCone, 1),
+                    new Object[] { " Y ", " X ", "X X", 'X', GCItems.heavyPlatingTier1, 'Y', Blocks.redstone_torch });
 
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.oxygenPipe, 6),
-                new Object[] { "XXX", "   ", "XXX", 'X', Blocks.glass_pane });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.oxygenPipe, 6),
+                    new Object[] { "XXX", "   ", "XXX", 'X', Blocks.glass_pane });
 
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.sensorGlasses, 1),
+                    new Object[] { "ZWZ", "Z Z", "XYX", 'W', Items.diamond, 'X', GCItems.sensorLens, 'Y',
+                            meteoricIronIngot, 'Z', Items.string });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.sensorLens, 1),
+                    new Object[] { "ZXZ", "XYX", "ZXZ", 'X', Blocks.glass_pane, 'Y', meteoricIronPlate, 'Z',
+                            Items.redstone });
+
+            if (!ConfigManagerCore.alternateCanisterRecipe) {
+                RecipeUtil.addRecipe(
+                        new ItemStack(GCItems.canister, 2, 0),
+                        new Object[] { "X X", "X X", "XXX", 'X', "ingotTin" });
+                RecipeUtil.addRecipe(
+                        new ItemStack(GCItems.canister, 2, 1),
+                        new Object[] { "X X", "X X", "XXX", 'X', "ingotCopper" });
+            } else {
+                RecipeUtil.addRecipe(
+                        new ItemStack(GCItems.canister, 2, 0),
+                        new Object[] { "XXX", "X  ", "XXX", 'X', "ingotTin" });
+                RecipeUtil.addRecipe(
+                        new ItemStack(GCItems.canister, 2, 1),
+                        new Object[] { "XXX", "X  ", "XXX", 'X', "ingotCopper" });
+            }
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.oxMask, 1),
+                    new Object[] { "XXX", "XYX", "XXX", 'X', Blocks.glass_pane, 'Y', Items.iron_helmet });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.canvas, 1),
+                    new Object[] { " XY", "XXX", "YX ", 'Y', Items.stick, 'X', Items.string });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.parachute, 1, 0),
+                    new Object[] { "XXX", "Y Y", " Y ", 'X', GCItems.canvas, 'Y', Items.string });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.sealableBlock, 1, 1),
+                    new Object[] { "XYX", 'Y', GCBlocks.oxygenPipe, 'X', new ItemStack(GCBlocks.basicBlock, 1, 4) });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.sealableBlock, 1, 14),
+                    new Object[] { "XYX", 'Y', new ItemStack(GCBlocks.aluminumWire, 1, 0), 'X',
+                            new ItemStack(GCBlocks.basicBlock, 1, 4) });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.sealableBlock, 1, 15),
+                    new Object[] { "XYX", 'Y', new ItemStack(GCBlocks.aluminumWire, 1, 1), 'X',
+                            new ItemStack(GCBlocks.basicBlock, 1, 4) });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.oxygenGear),
+                    new Object[] { " Y ", "YXY", "Y Y", 'X', GCItems.oxygenConcentrator, 'Y', GCBlocks.oxygenPipe });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.basicBlock, 4, 3),
+                    new Object[] { "   ", " XY", "   ", 'X', new ItemStack(Blocks.stone, 4, 0), 'Y', "compressedTin" });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.basicBlock, 4, 4),
+                    new Object[] { "   ", " X ", " Y ", 'X', new ItemStack(Blocks.stone, 4, 0), 'Y', "compressedTin" });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.partFins, 1),
+                    new Object[] { " Y ", "XYX", "X X", 'X', GCItems.heavyPlatingTier1, 'Y', "compressedSteel" });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.landingPad, 9, 0),
+                    new Object[] { "YYY", "XXX", 'X', Blocks.iron_block, 'Y', "compressedIron" });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.landingPad, 9, 1),
+                    new Object[] { "YYY", "XXX", 'X', Blocks.iron_block, 'Y', "compressedSteel" });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.partBuggy, 1, 0),
+                    new Object[] { " W ", "WXW", " W ", 'W', Items.leather, 'X', "compressedSteel" });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.partBuggy, 1, 1),
+                    new Object[] { "  Y", " ZY", "XXX", 'X', "compressedSteel", 'Y', "compressedSteel", 'Z',
+                            "compressedIron" });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.partBuggy, 1, 2),
+                    new Object[] { "XXX", "YZY", "XXX", 'X', "compressedSteel", 'Y', "compressedIron", 'Z',
+                            Blocks.chest });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.oxygenDetector, 1),
+                    new Object[] { "WWW", "YVY", "ZUZ", 'U', "compressedAluminum", 'V', "waferBasic", 'W',
+                            "compressedSteel", 'X', GCItems.oxygenFan, 'Y', GCItems.oxygenVent, 'Z', Items.redstone });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.oxygenDistributor, 1),
+                    new Object[] { "WXW", "YZY", "WXW", 'W', "compressedSteel", 'X', GCItems.oxygenFan, 'Y',
+                            GCItems.oxygenVent, 'Z', "compressedAluminum" });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.oxygenSealer, 1),
+                    new Object[] { "UZU", "YXY", "UZU", 'U', "compressedAluminum", 'V', GCBlocks.aluminumWire, 'W',
+                            "compressedSteel", 'X', GCItems.oxygenFan, 'Y', GCItems.oxygenVent, 'Z',
+                            "compressedSteel" });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.oxygenCollector, 1),
+                    new Object[] { "WWW", "YXZ", "UVU", 'U', "compressedAluminum", 'V', GCItems.oxygenConcentrator, 'W',
+                            "compressedSteel", 'X', new ItemStack(GCItems.canister, 1, 0), 'Y', GCItems.oxygenFan, 'Z',
+                            GCItems.oxygenVent });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.oxygenFan, 1),
+                    new Object[] { "Z Z", " Y ", "ZXZ", 'X', Items.redstone, 'Y', "waferBasic", 'Z',
+                            "compressedSteel" });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.oxygenConcentrator, 1),
+                    new Object[] { "ZWZ", "WYW", "ZXZ", 'W', "compressedTin", 'X', GCItems.oxygenVent, 'Y',
+                            new ItemStack(GCItems.canister, 1, 0), 'Z', "compressedSteel" });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.steelPickaxe, 1),
+                    new Object[] { "YYY", " X ", " X ", 'Y', "compressedSteel", 'X', Items.stick });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.steelAxe, 1),
+                    new Object[] { "YY ", "YX ", " X ", 'Y', "compressedSteel", 'X', Items.stick });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.steelAxe, 1),
+                    new Object[] { " YY", " XY", " X ", 'Y', "compressedSteel", 'X', Items.stick });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.steelHoe, 1),
+                    new Object[] { " YY", " X ", " X ", 'Y', "compressedSteel", 'X', Items.stick });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.steelHoe, 1),
+                    new Object[] { "YY ", " X ", " X ", 'Y', "compressedSteel", 'X', Items.stick });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.steelSpade, 1),
+                    new Object[] { " Y ", " X ", " X ", 'Y', "compressedSteel", 'X', Items.stick });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.steelSword, 1),
+                    new Object[] { " Y ", " Y ", " X ", 'Y', "compressedSteel", 'X', Items.stick });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.steelBoots, 1),
+                    new Object[] { "X X", "X X", 'X', "compressedSteel" });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.steelChestplate, 1),
+                    new Object[] { "X X", "XXX", "XXX", 'X', "compressedSteel" });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.steelLeggings, 1),
+                    new Object[] { "XXX", "X X", "X X", 'X', "compressedSteel" });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.steelHelmet, 1),
+                    new Object[] { "XXX", "X X", 'X', "compressedSteel" });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.flagPole, 2, 0),
+                    new Object[] { "X", "X", "X", 'X', "compressedSteel" });
+
+            CraftingManager.getInstance().getRecipeList().add(
+                    new ShapelessOreRecipe(
+                            new ItemStack(GCItems.oxygenVent, 1),
+                            "compressedTin",
+                            "compressedTin",
+                            "compressedTin",
+                            "compressedSteel"));
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.airLockFrame, 4, 0),
+                    new Object[] { "XXX", "YZY", "XXX", 'X', "compressedAluminum", 'Y', "compressedSteel", 'Z',
+                            GCItems.oxygenConcentrator });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.airLockFrame, 1, 1),
+                    new Object[] { "YYY", "WZW", "YYY", 'W', meteoricIronPlate, 'Y', "compressedSteel", 'Z',
+                            new ItemStack(GCItems.basicItem, 1, 13) });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.basicItem, 1, 20),
+                    new Object[] { "WVW", "YXY", "YZY", 'X', "compressedSteel", 'Y', "compressedBronze", 'Z',
+                            "waferBasic", 'W', Items.redstone, 'V', GCItems.oxygenVent });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.refinery),
+                    new Object[] { " Z ", "WZW", "XYX", 'X', "compressedSteel", 'Y', Blocks.furnace, 'Z',
+                            new ItemStack(GCItems.canister, 1, 1), 'W', Blocks.stone });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.oxygenCompressor, 1, 0),
+                    new Object[] { "XWX", "WZW", "XYX", 'W', "compressedAluminum", 'X', "compressedSteel", 'Y',
+                            "compressedBronze", 'Z', GCItems.oxygenConcentrator });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.oxygenCompressor, 1, 4),
+                    new Object[] { "XVX", "WZW", "XYX", 'V', GCItems.oxygenFan, 'W', "compressedAluminum", 'X',
+                            "compressedSteel", 'Y', Blocks.redstone_torch, 'Z', GCItems.oxygenConcentrator });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.fuelLoader),
+                    new Object[] { "XXX", "XZX", "WYW", 'W', "compressedAluminum", 'X', "compressedSteel", 'Y',
+                            "waferBasic", 'Z', new ItemStack(GCItems.canister, 1, 0) });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.basicItem, 2, 0),
+                    new Object[] { "XXX", "YYY", "ZZZ", 'X', Blocks.glass, 'Y', "waferSolar", 'Z',
+                            new ItemStack(GCBlocks.aluminumWire, 1, 0) });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.basicItem, 1, 1),
+                    new Object[] { "XXX", "YYY", "XXX", 'X', new ItemStack(GCItems.basicItem, 1, 0), 'Y',
+                            new ItemStack(GCBlocks.aluminumWire, 1, 0) });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.solarPanel, 1, 0),
+                    new Object[] { "XYX", "XZX", "VWV", 'V', new ItemStack(GCBlocks.aluminumWire, 1, 0), 'W',
+                            "waferBasic", 'X', "compressedSteel", 'Y', new ItemStack(GCItems.basicItem, 1, 1), 'Z',
+                            GCItems.flagPole });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.solarPanel, 1, 4),
+                    new Object[] { "XYX", "XZX", "VWV", 'V', new ItemStack(GCBlocks.aluminumWire, 1, 1), 'W',
+                            "waferAdvanced", 'X', "compressedSteel", 'Y', new ItemStack(GCItems.basicItem, 1, 1), 'Z',
+                            GCItems.flagPole });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.cargoLoader, 1, 0),
+                    new Object[] { "XWX", "YZY", "XXX", 'W', Blocks.hopper, 'X', "compressedSteel", 'Y',
+                            "compressedAluminum", 'Z', Blocks.chest });
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.cargoLoader, 1, 4),
+                    new Object[] { "XXX", "YZY", "XWX", 'W', Blocks.hopper, 'X', "compressedSteel", 'Y',
+                            "compressedAluminum", 'Z', Blocks.chest });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.oilCanister, 1, GCItems.oilCanister.getMaxDamage()),
+                    new Object[] { "WXW", "WYW", "WZW", 'X', "compressedSteel", 'Y', Blocks.glass, 'Z',
+                            new ItemStack(GCItems.canister, 1, 0), 'W', "compressedTin" });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.glowstoneTorch, 4),
+                    new Object[] { "Y", "X", 'X', Items.stick, 'Y', Items.glowstone_dust });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.basicItem, 1, 19),
+                    new Object[] { " X ", "YUY", "ZWZ", 'U', Items.repeater, 'W', "waferBasic", 'X',
+                            "compressedAluminum", 'Y', "compressedIron", 'Z', Items.redstone });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.wrench),
+                    new Object[] { "  Y", " X ", "X  ", 'X', "compressedBronze", 'Y', "compressedSteel" });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.spinThruster),
+                    new Object[] { "   ", "YWZ", "PXP", 'W', "waferAdvanced", 'X', meteoricIronIngot, 'Y',
+                            new ItemStack(GCItems.fuelCanister, 1, 1), 'Z', new ItemStack(GCItems.rocketEngine, 1, 0),
+                            'P', "compressedSteel" });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.screen),
+                    new Object[] { "XYX", "YGY", "XYX", 'X', "compressedSteel", 'Y', "waferBasic", 'G', Blocks.glass });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.telemetry),
+                    new Object[] { "XFX", "XWX", "YYY", 'W', "waferBasic", 'X', "compressedTin", 'Y',
+                            "compressedCopper", 'F', new ItemStack(GCItems.basicItem, 1, 19) });
+
+            RecipeUtil.addBlockRecipe(
+                    new ItemStack(GCBlocks.basicBlock, 1, 9),
+                    "ingotCopper",
+                    new ItemStack(GCItems.basicItem, 1, 3));
+
+            RecipeUtil.addBlockRecipe(
+                    new ItemStack(GCBlocks.basicBlock, 1, 10),
+                    "ingotTin",
+                    new ItemStack(GCItems.basicItem, 1, 4));
+
+            RecipeUtil.addBlockRecipe(
+                    new ItemStack(GCBlocks.basicBlock, 1, 11),
+                    "ingotAluminum",
+                    new ItemStack(GCItems.basicItem, 1, 5));
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.basicBlock, 1, 12),
+                    new Object[] { "YYY", "YYY", "YYY", 'Y', meteoricIronIngot });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.basicItem, 9, 3),
+                    new Object[] { "X", 'X', new ItemStack(GCBlocks.basicBlock, 1, 9) });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.basicItem, 9, 4),
+                    new Object[] { "X", 'X', new ItemStack(GCBlocks.basicBlock, 1, 10) });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.basicItem, 9, 5),
+                    new Object[] { "X", 'X', new ItemStack(GCBlocks.basicBlock, 1, 11) });
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCItems.meteoricIronIngot, 9, 0),
+                    new Object[] { "X", 'X', new ItemStack(GCBlocks.basicBlock, 1, 12) });
+
+            CraftingManager.getInstance().getRecipeList().add(
+                    new ShapelessOreRecipe(
+                            new ItemStack(GCItems.basicItem, 1, 15),
+                            new ItemStack(GCItems.canister, 1, 0),
+                            Items.apple,
+                            Items.apple));
+
+            CraftingManager.getInstance().getRecipeList().add(
+                    new ShapelessOreRecipe(
+                            new ItemStack(GCItems.basicItem, 1, 16),
+                            new ItemStack(GCItems.canister, 1, 0),
+                            Items.carrot,
+                            Items.carrot));
+
+            CraftingManager.getInstance().getRecipeList().add(
+                    new ShapelessOreRecipe(
+                            new ItemStack(GCItems.basicItem, 1, 17),
+                            new ItemStack(GCItems.canister, 1, 0),
+                            Items.melon,
+                            Items.melon));
+
+            CraftingManager.getInstance().getRecipeList().add(
+                    new ShapelessOreRecipe(
+                            new ItemStack(GCItems.basicItem, 1, 18),
+                            new ItemStack(GCItems.canister, 1, 0),
+                            Items.potato,
+                            Items.potato));
+
+            RecipeUtil.addRecipe(
+                    new ItemStack(GCBlocks.brightLamp),
+                    new Object[] { "XYX", "YZY", "XYX", 'X', deshIngot, 'Y', Items.glowstone_dust, 'Z',
+                            new ItemStack(GCItems.battery, 1, 0) });
+        }
         RecipeUtil.addRecipe(
                 new ItemStack(GCItems.oxTankLight, 1, GCItems.oxTankLight.getMaxDamage()),
                 new Object[] { "YZY", "YXY", "YYY", 'X', new ItemStack(GCItems.canister, 1, 0), 'Y',
@@ -285,77 +630,6 @@ public class RecipeManagerGC {
                 new ItemStack(GCItems.oxTankLight, 1, GCItems.oxTankLight.getMaxDamage()),
                 new Object[] { "YZY", "YXY", "YYY", 'X', new ItemStack(GCItems.canister, 1, 1), 'Y',
                         "compressedAluminum", 'Z', GCBlocks.oxygenPipe });
-
-        // RecipeUtil.addRecipe(new ItemStack(GCItems.oxTankMedium, 1,
-        // GCItems.oxTankMedium.getMaxDamage()), new
-        // Object[] { "ZZ", "XX", "YY", 'X', new ItemStack(GCItems.canister, 1, 0), 'Y',
-        // "compressedMeteoricIron", 'Z',
-        // GCBlocks.oxygenPipe});
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.sensorGlasses, 1),
-                new Object[] { "ZWZ", "Z Z", "XYX", 'W', Items.diamond, 'X', GCItems.sensorLens, 'Y', meteoricIronIngot,
-                        'Z', Items.string });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.sensorLens, 1),
-                new Object[] { "ZXZ", "XYX", "ZXZ", 'X', Blocks.glass_pane, 'Y', meteoricIronPlate, 'Z',
-                        Items.redstone });
-
-        if (!ConfigManagerCore.alternateCanisterRecipe) {
-            RecipeUtil.addRecipe(
-                    new ItemStack(GCItems.canister, 2, 0),
-                    new Object[] { "X X", "X X", "XXX", 'X', "ingotTin" });
-            RecipeUtil.addRecipe(
-                    new ItemStack(GCItems.canister, 2, 1),
-                    new Object[] { "X X", "X X", "XXX", 'X', "ingotCopper" });
-        } else {
-            RecipeUtil.addRecipe(
-                    new ItemStack(GCItems.canister, 2, 0),
-                    new Object[] { "XXX", "X  ", "XXX", 'X', "ingotTin" });
-            RecipeUtil.addRecipe(
-                    new ItemStack(GCItems.canister, 2, 1),
-                    new Object[] { "XXX", "X  ", "XXX", 'X', "ingotCopper" });
-        }
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.oxMask, 1),
-                new Object[] { "XXX", "XYX", "XXX", 'X', Blocks.glass_pane, 'Y', Items.iron_helmet });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.canvas, 1),
-                new Object[] { " XY", "XXX", "YX ", 'Y', Items.stick, 'X', Items.string });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.parachute, 1, 0),
-                new Object[] { "XXX", "Y Y", " Y ", 'X', GCItems.canvas, 'Y', Items.string });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.sealableBlock, 1, 1),
-                new Object[] { "XYX", 'Y', GCBlocks.oxygenPipe, 'X', new ItemStack(GCBlocks.basicBlock, 1, 4) });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.sealableBlock, 1, 14),
-                new Object[] { "XYX", 'Y', new ItemStack(GCBlocks.aluminumWire, 1, 0), 'X',
-                        new ItemStack(GCBlocks.basicBlock, 1, 4) });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.sealableBlock, 1, 15),
-                new Object[] { "XYX", 'Y', new ItemStack(GCBlocks.aluminumWire, 1, 1), 'X',
-                        new ItemStack(GCBlocks.basicBlock, 1, 4) });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.oxygenGear),
-                new Object[] { " Y ", "YXY", "Y Y", 'X', GCItems.oxygenConcentrator, 'Y', GCBlocks.oxygenPipe });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.basicBlock, 4, 3),
-                new Object[] { "   ", " XY", "   ", 'X', new ItemStack(Blocks.stone, 4, 0), 'Y', "compressedTin" });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.basicBlock, 4, 4),
-                new Object[] { "   ", " X ", " Y ", 'X', new ItemStack(Blocks.stone, 4, 0), 'Y', "compressedTin" });
-
         RecipeUtil.addRecipe(
                 new ItemStack(GCItems.flag),
                 new Object[] { "XYY", "XYY", "X  ", 'X', GCItems.flagPole, 'Y', GCItems.canvas });
@@ -368,276 +642,9 @@ public class RecipeManagerGC {
         }
 
         RecipeUtil.addRecipe(
-                new ItemStack(GCItems.partFins, 1),
-                new Object[] { " Y ", "XYX", "X X", 'X', GCItems.heavyPlatingTier1, 'Y', "compressedSteel" });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.landingPad, 9, 0),
-                new Object[] { "YYY", "XXX", 'X', Blocks.iron_block, 'Y', "compressedIron" });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.landingPad, 9, 1),
-                new Object[] { "YYY", "XXX", 'X', Blocks.iron_block, 'Y', "compressedSteel" });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.partBuggy, 1, 0),
-                new Object[] { " W ", "WXW", " W ", 'W', Items.leather, 'X', "compressedSteel" });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.partBuggy, 1, 1),
-                new Object[] { "  Y", " ZY", "XXX", 'X', "compressedSteel", 'Y', "compressedSteel", 'Z',
-                        "compressedIron" });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.partBuggy, 1, 2),
-                new Object[] { "XXX", "YZY", "XXX", 'X', "compressedSteel", 'Y', "compressedIron", 'Z', Blocks.chest });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.oxygenDetector, 1),
-                new Object[] { "WWW", "YVY", "ZUZ", 'U', "compressedAluminum", 'V', "waferBasic", 'W',
-                        "compressedSteel", 'X', GCItems.oxygenFan, 'Y', GCItems.oxygenVent, 'Z', Items.redstone });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.oxygenDistributor, 1),
-                new Object[] { "WXW", "YZY", "WXW", 'W', "compressedSteel", 'X', GCItems.oxygenFan, 'Y',
-                        GCItems.oxygenVent, 'Z', "compressedAluminum" });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.oxygenSealer, 1),
-                new Object[] { "UZU", "YXY", "UZU", 'U', "compressedAluminum", 'V', GCBlocks.aluminumWire, 'W',
-                        "compressedSteel", 'X', GCItems.oxygenFan, 'Y', GCItems.oxygenVent, 'Z', "compressedSteel" });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.oxygenCollector, 1),
-                new Object[] { "WWW", "YXZ", "UVU", 'U', "compressedAluminum", 'V', GCItems.oxygenConcentrator, 'W',
-                        "compressedSteel", 'X', new ItemStack(GCItems.canister, 1, 0), 'Y', GCItems.oxygenFan, 'Z',
-                        GCItems.oxygenVent });
-
-        // Handled by Galaxy Space
-        // RecipeUtil.addRecipe(new ItemStack(GCBlocks.nasaWorkbench, 1), new Object[] {
-        // "XZX", "UWU", "YVY", 'U',
-        // Blocks.lever, 'V', Blocks.redstone_torch, 'W', "waferAdvanced", 'X',
-        // "compressedSteel", 'Y',
-        // "compressedSteel", 'Z', Blocks.crafting_table });
-
-        // RecipeUtil.addRecipe(new ItemStack(GCItems.oxTankHeavy, 1,
-        // GCItems.oxTankHeavy.getMaxDamage()), new Object[]
-        // { "ZZZ", "XXX", "YYY", 'X', new ItemStack(GCItems.canister, 1, 0), 'Y',
-        // "compressedSteel", 'Z', new
-        // ItemStack(Blocks.wool, 1, 14) });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.oxygenFan, 1),
-                new Object[] { "Z Z", " Y ", "ZXZ", 'X', Items.redstone, 'Y', "waferBasic", 'Z', "compressedSteel" });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.oxygenConcentrator, 1),
-                new Object[] { "ZWZ", "WYW", "ZXZ", 'W', "compressedTin", 'X', GCItems.oxygenVent, 'Y',
-                        new ItemStack(GCItems.canister, 1, 0), 'Z', "compressedSteel" });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.steelPickaxe, 1),
-                new Object[] { "YYY", " X ", " X ", 'Y', "compressedSteel", 'X', Items.stick });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.steelAxe, 1),
-                new Object[] { "YY ", "YX ", " X ", 'Y', "compressedSteel", 'X', Items.stick });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.steelAxe, 1),
-                new Object[] { " YY", " XY", " X ", 'Y', "compressedSteel", 'X', Items.stick });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.steelHoe, 1),
-                new Object[] { " YY", " X ", " X ", 'Y', "compressedSteel", 'X', Items.stick });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.steelHoe, 1),
-                new Object[] { "YY ", " X ", " X ", 'Y', "compressedSteel", 'X', Items.stick });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.steelSpade, 1),
-                new Object[] { " Y ", " X ", " X ", 'Y', "compressedSteel", 'X', Items.stick });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.steelSword, 1),
-                new Object[] { " Y ", " Y ", " X ", 'Y', "compressedSteel", 'X', Items.stick });
-
-        RecipeUtil
-                .addRecipe(new ItemStack(GCItems.steelBoots, 1), new Object[] { "X X", "X X", 'X', "compressedSteel" });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.steelChestplate, 1),
-                new Object[] { "X X", "XXX", "XXX", 'X', "compressedSteel" });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.steelLeggings, 1),
-                new Object[] { "XXX", "X X", "X X", 'X', "compressedSteel" });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.steelHelmet, 1),
-                new Object[] { "XXX", "X X", 'X', "compressedSteel" });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.flagPole, 2, 0),
-                new Object[] { "X", "X", "X", 'X', "compressedSteel" });
-
-        CraftingManager.getInstance().getRecipeList().add(
-                new ShapelessOreRecipe(
-                        new ItemStack(GCItems.oxygenVent, 1),
-                        "compressedTin",
-                        "compressedTin",
-                        "compressedTin",
-                        "compressedSteel"));
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.airLockFrame, 4, 0),
-                new Object[] { "XXX", "YZY", "XXX", 'X', "compressedAluminum", 'Y', "compressedSteel", 'Z',
-                        GCItems.oxygenConcentrator });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.airLockFrame, 1, 1),
-                new Object[] { "YYY", "WZW", "YYY", 'W', meteoricIronPlate, 'Y', "compressedSteel", 'Z',
-                        new ItemStack(GCItems.basicItem, 1, 13) });
-
-        // Disable oil extractor:
-        // RecipeUtil.addRecipe(new ItemStack(GCItems.oilExtractor), new Object[] { "X
-        // ", " XY", "ZYY", 'X',
-        // "compressedSteel", 'Y', "compressedBronze", 'Z', Items.redstone });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.basicItem, 1, 20),
-                new Object[] { "WVW", "YXY", "YZY", 'X', "compressedSteel", 'Y', "compressedBronze", 'Z', "waferBasic",
-                        'W', Items.redstone, 'V', GCItems.oxygenVent });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.oilCanister, 1, GCItems.oilCanister.getMaxDamage()),
-                new Object[] { "WXW", "WYW", "WZW", 'X', "compressedSteel", 'Y', Blocks.glass, 'Z',
-                        new ItemStack(GCItems.canister, 1, 0), 'W', "compressedTin" });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.refinery),
-                new Object[] { " Z ", "WZW", "XYX", 'X', "compressedSteel", 'Y', Blocks.furnace, 'Z',
-                        new ItemStack(GCItems.canister, 1, 1), 'W', Blocks.stone });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.oxygenCompressor, 1, 0),
-                new Object[] { "XWX", "WZW", "XYX", 'W', "compressedAluminum", 'X', "compressedSteel", 'Y',
-                        "compressedBronze", 'Z', GCItems.oxygenConcentrator });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.oxygenCompressor, 1, 4),
-                new Object[] { "XVX", "WZW", "XYX", 'V', GCItems.oxygenFan, 'W', "compressedAluminum", 'X',
-                        "compressedSteel", 'Y', Blocks.redstone_torch, 'Z', GCItems.oxygenConcentrator });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.fuelLoader),
-                new Object[] { "XXX", "XZX", "WYW", 'W', "compressedAluminum", 'X', "compressedSteel", 'Y',
-                        "waferBasic", 'Z', new ItemStack(GCItems.canister, 1, 0) });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.basicItem, 2, 0),
-                new Object[] { "XXX", "YYY", "ZZZ", 'X', Blocks.glass, 'Y', "waferSolar", 'Z',
-                        new ItemStack(GCBlocks.aluminumWire, 1, 0) });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.basicItem, 1, 1),
-                new Object[] { "XXX", "YYY", "XXX", 'X', new ItemStack(GCItems.basicItem, 1, 0), 'Y',
-                        new ItemStack(GCBlocks.aluminumWire, 1, 0) });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.solarPanel, 1, 0),
-                new Object[] { "XYX", "XZX", "VWV", 'V', new ItemStack(GCBlocks.aluminumWire, 1, 0), 'W', "waferBasic",
-                        'X', "compressedSteel", 'Y', new ItemStack(GCItems.basicItem, 1, 1), 'Z', GCItems.flagPole });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.solarPanel, 1, 4),
-                new Object[] { "XYX", "XZX", "VWV", 'V', new ItemStack(GCBlocks.aluminumWire, 1, 1), 'W',
-                        "waferAdvanced", 'X', "compressedSteel", 'Y', new ItemStack(GCItems.basicItem, 1, 1), 'Z',
-                        GCItems.flagPole });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.cargoLoader, 1, 0),
-                new Object[] { "XWX", "YZY", "XXX", 'W', Blocks.hopper, 'X', "compressedSteel", 'Y',
-                        "compressedAluminum", 'Z', Blocks.chest });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.cargoLoader, 1, 4),
-                new Object[] { "XXX", "YZY", "XWX", 'W', Blocks.hopper, 'X', "compressedSteel", 'Y',
-                        "compressedAluminum", 'Z', Blocks.chest });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.glowstoneTorch, 4),
-                new Object[] { "Y", "X", 'X', Items.stick, 'Y', Items.glowstone_dust });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.basicItem, 1, 19),
-                new Object[] { " X ", "YUY", "ZWZ", 'U', Items.repeater, 'W', "waferBasic", 'X', "compressedAluminum",
-                        'Y', "compressedIron", 'Z', Items.redstone });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.wrench),
-                new Object[] { "  Y", " X ", "X  ", 'X', "compressedBronze", 'Y', "compressedSteel" });
-
-        RecipeUtil.addRecipe(
                 new ItemStack(Blocks.lit_pumpkin),
                 new Object[] { "P  ", "T  ", "   ", 'P', new ItemStack(Blocks.pumpkin), 'T',
                         new ItemStack(GCBlocks.unlitTorch) });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.brightLamp),
-                new Object[] { "XYX", "YZY", "XYX", 'X', deshIngot, 'Y', Items.glowstone_dust, 'Z',
-                        new ItemStack(GCItems.battery, 1, 0) });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.spinThruster),
-                new Object[] { "   ", "YWZ", "PXP", 'W', "waferAdvanced", 'X', meteoricIronIngot, 'Y',
-                        new ItemStack(GCItems.fuelCanister, 1, 1), 'Z', new ItemStack(GCItems.rocketEngine, 1, 0), 'P',
-                        "compressedSteel" });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.screen),
-                new Object[] { "XYX", "YGY", "XYX", 'X', "compressedSteel", 'Y', "waferBasic", 'G', Blocks.glass });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.telemetry),
-                new Object[] { "XFX", "XWX", "YYY", 'W', "waferBasic", 'X', "compressedTin", 'Y', "compressedCopper",
-                        'F', new ItemStack(GCItems.basicItem, 1, 19) });
-
-        RecipeUtil.addBlockRecipe(
-                new ItemStack(GCBlocks.basicBlock, 1, 9),
-                "ingotCopper",
-                new ItemStack(GCItems.basicItem, 1, 3));
-
-        RecipeUtil.addBlockRecipe(
-                new ItemStack(GCBlocks.basicBlock, 1, 10),
-                "ingotTin",
-                new ItemStack(GCItems.basicItem, 1, 4));
-
-        RecipeUtil.addBlockRecipe(
-                new ItemStack(GCBlocks.basicBlock, 1, 11),
-                "ingotAluminum",
-                new ItemStack(GCItems.basicItem, 1, 5));
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCBlocks.basicBlock, 1, 12),
-                new Object[] { "YYY", "YYY", "YYY", 'Y', meteoricIronIngot });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.basicItem, 9, 3),
-                new Object[] { "X", 'X', new ItemStack(GCBlocks.basicBlock, 1, 9) });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.basicItem, 9, 4),
-                new Object[] { "X", 'X', new ItemStack(GCBlocks.basicBlock, 1, 10) });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.basicItem, 9, 5),
-                new Object[] { "X", 'X', new ItemStack(GCBlocks.basicBlock, 1, 11) });
-
-        RecipeUtil.addRecipe(
-                new ItemStack(GCItems.meteoricIronIngot, 9, 0),
-                new Object[] { "X", 'X', new ItemStack(GCBlocks.basicBlock, 1, 12) });
 
         RecipeUtil.addRecipe(
                 new ItemStack(GCBlocks.cheeseBlock, 1),
@@ -705,71 +712,46 @@ public class RecipeManagerGC {
                 new ItemStack(GCBlocks.wallGC, 6, 3),
                 new Object[] { "XXX", "XXX", 'X', new ItemStack(GCBlocks.blockMoon, 1, 14) });
 
-        CraftingManager.getInstance().getRecipeList().add(
-                new ShapelessOreRecipe(
-                        new ItemStack(GCItems.basicItem, 1, 15),
-                        new ItemStack(GCItems.canister, 1, 0),
-                        Items.apple,
-                        Items.apple));
-
-        CraftingManager.getInstance().getRecipeList().add(
-                new ShapelessOreRecipe(
-                        new ItemStack(GCItems.basicItem, 1, 16),
-                        new ItemStack(GCItems.canister, 1, 0),
-                        Items.carrot,
-                        Items.carrot));
-
-        CraftingManager.getInstance().getRecipeList().add(
-                new ShapelessOreRecipe(
-                        new ItemStack(GCItems.basicItem, 1, 17),
-                        new ItemStack(GCItems.canister, 1, 0),
-                        Items.melon,
-                        Items.melon));
-
-        CraftingManager.getInstance().getRecipeList().add(
-                new ShapelessOreRecipe(
-                        new ItemStack(GCItems.basicItem, 1, 18),
-                        new ItemStack(GCItems.canister, 1, 0),
-                        Items.potato,
-                        Items.potato));
-
         CraftingManager.getInstance().getRecipeList()
                 .add(new ShapelessOreRecipe(new ItemStack(GCItems.meteorChunk, 3), GCItems.meteoricIronRaw));
 
-        for (int i = 3; i < 6; i++) {
-            if (ItemBasic.names[i].contains("ingot")) {
-                CompressorRecipes.addShapelessRecipe(
-                        new ItemStack(GCItems.basicItem, 1, i + 3),
-                        ItemBasic.names[i],
-                        ItemBasic.names[i]);
+        if (!Loader.isModLoaded(Constants.MOD_ID_NEW_HORIZONS_CORE_MOD)) {
+            for (int i = 3; i < 6; i++) {
+                if (ItemBasic.names[i].contains("ingot")) {
+                    CompressorRecipes.addShapelessRecipe(
+                            new ItemStack(GCItems.basicItem, 1, i + 3),
+                            ItemBasic.names[i],
+                            ItemBasic.names[i]);
+                }
             }
-        }
 
-        /*
-         * // Support for all the spellings of Aluminum for (ItemStack stack : aluminumIngots) {
-         * CompressorRecipes.addShapelessRecipe(new ItemStack(GCItems.basicItem, 1, 8), stack, stack); }
-         */
-        if (OreDictionary.getOres("ingotBronze").size() > 0) {
-            CompressorRecipes.addShapelessRecipe(new ItemStack(GCItems.basicItem, 1, 10), "ingotBronze", "ingotBronze");
-        }
+            /*
+             * // Support for all the spellings of Aluminum for (ItemStack stack : aluminumIngots) {
+             * CompressorRecipes.addShapelessRecipe(new ItemStack(GCItems.basicItem, 1, 8), stack, stack); }
+             */
+            if (OreDictionary.getOres("ingotBronze").size() > 0) {
+                CompressorRecipes
+                        .addShapelessRecipe(new ItemStack(GCItems.basicItem, 1, 10), "ingotBronze", "ingotBronze");
+            }
 
-        CompressorRecipes.addShapelessRecipe(
-                new ItemStack(GCItems.basicItem, 1, 10),
-                new ItemStack(GCItems.basicItem, 1, 6),
-                new ItemStack(GCItems.basicItem, 1, 7));
-        CompressorRecipes
-                .addShapelessRecipe(new ItemStack(GCItems.basicItem, 1, 11), Items.iron_ingot, Items.iron_ingot);
-        CompressorRecipes.addShapelessRecipe(new ItemStack(GCItems.meteoricIronIngot, 1, 1), meteoricIronIngot);
-        CompressorRecipes.addRecipe(
-                new ItemStack(GCItems.heavyPlatingTier1, 2, 0),
-                "XYZ",
-                "XYZ",
-                'X',
-                new ItemStack(GCItems.basicItem, 1, 9),
-                'Y',
-                new ItemStack(GCItems.basicItem, 1, 8),
-                'Z',
-                new ItemStack(GCItems.basicItem, 1, 10));
+            CompressorRecipes.addShapelessRecipe(
+                    new ItemStack(GCItems.basicItem, 1, 10),
+                    new ItemStack(GCItems.basicItem, 1, 6),
+                    new ItemStack(GCItems.basicItem, 1, 7));
+            CompressorRecipes
+                    .addShapelessRecipe(new ItemStack(GCItems.basicItem, 1, 11), Items.iron_ingot, Items.iron_ingot);
+            CompressorRecipes.addShapelessRecipe(new ItemStack(GCItems.meteoricIronIngot, 1, 1), meteoricIronIngot);
+            CompressorRecipes.addRecipe(
+                    new ItemStack(GCItems.heavyPlatingTier1, 2, 0),
+                    "XYZ",
+                    "XYZ",
+                    'X',
+                    new ItemStack(GCItems.basicItem, 1, 9),
+                    'Y',
+                    new ItemStack(GCItems.basicItem, 1, 8),
+                    'Z',
+                    new ItemStack(GCItems.basicItem, 1, 10));
+        }
     }
 
     public static void setConfigurableRecipes() {


### PR DESCRIPTION
a lot recipes will only be loaded outside of GTNH and copper, alu, tin, meteoric iron ingot are also not (really) added for GTNH anymore.

brings the number of copper ingots in GTNH down to just 4 XD.

Goes together with the NHCoreMod PR here: https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1136

related to https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18622