### PR TITLE
Add config option + Translucency enchant to hide GC gear from rendering on the player body

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/model/ModelPlayerGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/model/ModelPlayerGC.java
@@ -250,21 +250,21 @@ public class ModelPlayerGC extends ModelBiped {
 
         if (gearData != null) {
             this.usingParachute = gearData.getParachute() != null;
-            wearingMask = gearData.getMask() > -1;
-            wearingGear = gearData.getGear() > -1;
-            wearingLeftTankGreen = gearData.getLeftTank() == 0;
-            wearingLeftTankOrange = gearData.getLeftTank() == 1;
-            wearingLeftTankRed = gearData.getLeftTank() == 2;
-            wearingLeftTankBlue = gearData.getLeftTank() == 3;
-            wearingLeftTankViolet = gearData.getLeftTank() == 4;
-            wearingLeftTankGray = gearData.getLeftTank() == Integer.MAX_VALUE;
-            wearingRightTankGreen = gearData.getRightTank() == 0;
-            wearingRightTankOrange = gearData.getRightTank() == 1;
-            wearingRightTankRed = gearData.getRightTank() == 2;
-            wearingRightTankBlue = gearData.getRightTank() == 3;
-            wearingRightTankViolet = gearData.getRightTank() == 4;
-            wearingRightTankGray = gearData.getRightTank() == Integer.MAX_VALUE;
-            wearingFrequencyModule = gearData.getFrequencyModule() > -1;
+            wearingMask = gearData.getMask() > -1 && gearData.getRenderMask();
+            wearingGear = gearData.getGear() > -1 && gearData.getRenderGear();
+            wearingLeftTankGreen = gearData.getLeftTank() == 0 && gearData.getRenderLeftTank();
+            wearingLeftTankOrange = gearData.getLeftTank() == 1 && gearData.getRenderLeftTank();
+            wearingLeftTankRed = gearData.getLeftTank() == 2 && gearData.getRenderLeftTank();
+            wearingLeftTankBlue = gearData.getLeftTank() == 3 && gearData.getRenderLeftTank();
+            wearingLeftTankViolet = gearData.getLeftTank() == 4 && gearData.getRenderLeftTank();
+            wearingLeftTankGray = gearData.getLeftTank() == Integer.MAX_VALUE && gearData.getRenderLeftTank();
+            wearingRightTankGreen = gearData.getRightTank() == 0 && gearData.getRenderRightTank();
+            wearingRightTankOrange = gearData.getRightTank() == 1 && gearData.getRenderRightTank();
+            wearingRightTankRed = gearData.getRightTank() == 2 && gearData.getRenderRightTank();
+            wearingRightTankBlue = gearData.getRightTank() == 3 && gearData.getRenderRightTank();
+            wearingRightTankViolet = gearData.getRightTank() == 4 && gearData.getRenderRightTank();
+            wearingRightTankGray = gearData.getRightTank() == Integer.MAX_VALUE && gearData.getRenderRightTank();
+            wearingFrequencyModule = gearData.getFrequencyModule() > -1 && gearData.getRenderFrequencyModule();
         } else {
             final String id = player.getGameProfile().getName();
 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/entities/RenderPlayerGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/entities/RenderPlayerGC.java
@@ -95,13 +95,15 @@ public class RenderPlayerGC extends RenderPlayer {
                         if (padding == 0 && !par1EntityLivingBase.isInvisible()) {
                             GL11.glColor4f(1, 1, 1, 1);
                             Minecraft.getMinecraft().renderEngine.bindTexture(RenderPlayerGC.thermalPaddingTexture1);
-                            modelBiped.bipedHead.showModel = i == 0;
-                            modelBiped.bipedHeadwear.showModel = i == 0;
-                            modelBiped.bipedBody.showModel = i == 1 || i == 2;
-                            modelBiped.bipedRightArm.showModel = i == 1;
-                            modelBiped.bipedLeftArm.showModel = i == 1;
-                            modelBiped.bipedRightLeg.showModel = i == 2 || i == 3;
-                            modelBiped.bipedLeftLeg.showModel = i == 2 || i == 3;
+                            modelBiped.bipedHead.showModel = i == 0 && gearData.getRenderThermalPadding(i);
+                            modelBiped.bipedHeadwear.showModel = i == 0 && gearData.getRenderThermalPadding(i);
+                            modelBiped.bipedBody.showModel = (i == 1 || i == 2) && gearData.getRenderThermalPadding(i);
+                            modelBiped.bipedRightArm.showModel = i == 1 && gearData.getRenderThermalPadding(i);
+                            modelBiped.bipedLeftArm.showModel = i == 1 && gearData.getRenderThermalPadding(i);
+                            modelBiped.bipedRightLeg.showModel = (i == 2 || i == 3)
+                                    && gearData.getRenderThermalPadding(i);
+                            modelBiped.bipedLeftLeg.showModel = (i == 2 || i == 3)
+                                    && gearData.getRenderThermalPadding(i);
 
                             modelBiped.onGround = thisInst.mainModel.onGround;
                             modelBiped.isRiding = thisInst.mainModel.isRiding;

--- a/src/main/java/micdoodle8/mods/galacticraft/core/entities/player/GCPlayerHandler.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/entities/player/GCPlayerHandler.java
@@ -169,10 +169,10 @@ public class GCPlayerHandler {
     }
 
     // --- WitchingGadgets Translucent II enchant support
-    private static int translucentID = -6;
+    private static Integer translucentID = null;
 
-    public static int getTranslucentID() {
-        if (translucentID == -6) setTranslucentID();
+    public static Integer getTranslucentID() {
+        if (translucentID == null) setTranslucentID();
         return translucentID;
     }
 
@@ -183,12 +183,12 @@ public class GCPlayerHandler {
                 return;
             }
         }
-        translucentID = -1;
+        translucentID = null;
     }
 
     public static int getTranslucencyLevel(ItemStack stack) {
-        int translucent = getTranslucentID();
-        if (translucent > 0) return EnchantmentHelper.getEnchantmentLevel(translucent, stack);
+        Integer translucent = getTranslucentID();
+        if (translucent != null) return EnchantmentHelper.getEnchantmentLevel(translucent, stack);
         else return 0;
     }
 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/entities/player/GCPlayerHandler.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/entities/player/GCPlayerHandler.java
@@ -13,6 +13,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityClientPlayerMP;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -164,6 +166,30 @@ public class GCPlayerHandler {
         }
 
         stats.player = new WeakReference<>(player);
+    }
+
+    // --- WitchingGadgets Translucent II enchant support
+    private static int translucentID = -6;
+
+    public static int getTranslucentID() {
+        if (translucentID == -6) setTranslucentID();
+        return translucentID;
+    }
+
+    private static void setTranslucentID() {
+        for (Enchantment ench : Enchantment.enchantmentsList) {
+            if (ench != null && ench.getName().equals("enchantment.wg.invisibleGear")) {
+                translucentID = ench.effectId;
+                return;
+            }
+        }
+        translucentID = -1;
+    }
+
+    public static int getTranslucencyLevel(ItemStack stack) {
+        int translucent = getTranslucentID();
+        if (translucent > 0) return EnchantmentHelper.getEnchantmentLevel(translucent, stack);
+        else return 0;
     }
 
     public static void checkGear(EntityPlayerMP player, GCPlayerStats GCPlayer, boolean forceSend) {
@@ -372,6 +398,44 @@ public class GCPlayerHandler {
 
             GCPlayer.lastThermalBootsInSlot = GCPlayer.thermalBootsInSlot;
         }
+        checkRenderGear(player);
+    }
+
+    public static void checkRenderGear(EntityPlayerMP player) {
+        GCPlayerStats GCPlayer = GCPlayerStats.get(player);
+        boolean disableGearRender = ConfigManagerCore.disableGearRender;
+        if (GCPlayer.frequencyModuleInSlot != null
+                && (getTranslucencyLevel(GCPlayer.frequencyModuleInSlot) == 2 || disableGearRender))
+            GCPlayerHandler.sendGearUpdatePacket(player, EnumModelPacket.HIDEFREQUENCYMODULE);
+        else GCPlayerHandler.sendGearUpdatePacket(player, EnumModelPacket.SHOWFREQUENCYMODULE);
+        if (GCPlayer.maskInSlot != null && (getTranslucencyLevel(GCPlayer.maskInSlot) == 2 || disableGearRender))
+            GCPlayerHandler.sendGearUpdatePacket(player, EnumModelPacket.HIDEMASK);
+        else GCPlayerHandler.sendGearUpdatePacket(player, EnumModelPacket.SHOWMASK);
+        if (GCPlayer.gearInSlot != null && (getTranslucencyLevel(GCPlayer.gearInSlot) == 2 || disableGearRender))
+            GCPlayerHandler.sendGearUpdatePacket(player, EnumModelPacket.HIDEGEAR);
+        else GCPlayerHandler.sendGearUpdatePacket(player, EnumModelPacket.SHOWGEAR);
+        if (GCPlayer.tankInSlot1 != null && (getTranslucencyLevel(GCPlayer.tankInSlot1) == 2 || disableGearRender))
+            GCPlayerHandler.sendGearUpdatePacket(player, EnumModelPacket.HIDELEFTTANK);
+        else GCPlayerHandler.sendGearUpdatePacket(player, EnumModelPacket.SHOWLEFTTANK);
+        if (GCPlayer.tankInSlot2 != null && (getTranslucencyLevel(GCPlayer.tankInSlot2) == 2 || disableGearRender))
+            GCPlayerHandler.sendGearUpdatePacket(player, EnumModelPacket.HIDERIGHTTANK);
+        else GCPlayerHandler.sendGearUpdatePacket(player, EnumModelPacket.SHOWRIGHTTANK);
+        if (GCPlayer.thermalHelmetInSlot != null
+                && (getTranslucencyLevel(GCPlayer.thermalHelmetInSlot) == 2 || disableGearRender))
+            GCPlayerHandler.sendGearUpdatePacket(player, EnumModelPacket.HIDETHERMALHELMET);
+        else GCPlayerHandler.sendGearUpdatePacket(player, EnumModelPacket.SHOWTHERMALHELMET);
+        if (GCPlayer.thermalChestplateInSlot != null
+                && (getTranslucencyLevel(GCPlayer.thermalChestplateInSlot) == 2 || disableGearRender))
+            GCPlayerHandler.sendGearUpdatePacket(player, EnumModelPacket.HIDETHERMALCHESTPLATE);
+        else GCPlayerHandler.sendGearUpdatePacket(player, EnumModelPacket.SHOWTHERMALCHESTPLATE);
+        if (GCPlayer.thermalLeggingsInSlot != null
+                && (getTranslucencyLevel(GCPlayer.thermalLeggingsInSlot) == 2 || disableGearRender))
+            GCPlayerHandler.sendGearUpdatePacket(player, EnumModelPacket.HIDETHERMALLEGGINGS);
+        else GCPlayerHandler.sendGearUpdatePacket(player, EnumModelPacket.SHOWTHERMALLEGGINGS);
+        if (GCPlayer.thermalBootsInSlot != null
+                && (getTranslucencyLevel(GCPlayer.thermalBootsInSlot) == 2 || disableGearRender))
+            GCPlayerHandler.sendGearUpdatePacket(player, EnumModelPacket.HIDETHERMALBOOTS);
+        else GCPlayerHandler.sendGearUpdatePacket(player, EnumModelPacket.SHOWTHERMALBOOTS);
     }
 
     protected void checkThermalStatus(EntityPlayerMP player, GCPlayerStats playerStats) {
@@ -990,7 +1054,25 @@ public class GCPlayerHandler {
         REMOVE_THERMAL_HELMET,
         REMOVE_THERMAL_CHESTPLATE,
         REMOVE_THERMAL_LEGGINGS,
-        REMOVE_THERMAL_BOOTS
+        REMOVE_THERMAL_BOOTS,
+        SHOWMASK,
+        HIDEMASK,
+        SHOWGEAR,
+        HIDEGEAR,
+        SHOWLEFTTANK,
+        HIDELEFTTANK,
+        SHOWRIGHTTANK,
+        HIDERIGHTTANK,
+        SHOWFREQUENCYMODULE,
+        HIDEFREQUENCYMODULE,
+        SHOWTHERMALHELMET,
+        SHOWTHERMALCHESTPLATE,
+        SHOWTHERMALLEGGINGS,
+        SHOWTHERMALBOOTS,
+        HIDETHERMALHELMET,
+        HIDETHERMALCHESTPLATE,
+        HIDETHERMALLEGGINGS,
+        HIDETHERMALBOOTS
     }
 
     public void onPlayerUpdate(EntityPlayerMP player) {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/network/PacketSimple.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/network/PacketSimple.java
@@ -499,6 +499,60 @@ public class PacketSimple extends Packet implements IPacket {
                         case REMOVE_THERMAL_BOOTS:
                             gearData.setThermalPadding(3, -1);
                             break;
+                        case SHOWMASK:
+                            gearData.setRenderMask(true);
+                            break;
+                        case HIDEMASK:
+                            gearData.setRenderMask(false);
+                            break;
+                        case SHOWGEAR:
+                            gearData.setRenderGear(true);
+                            break;
+                        case HIDEGEAR:
+                            gearData.setRenderGear(false);
+                            break;
+                        case SHOWLEFTTANK:
+                            gearData.setRenderLeftTank(true);
+                            break;
+                        case HIDELEFTTANK:
+                            gearData.setRenderLeftTank(false);
+                            break;
+                        case SHOWRIGHTTANK:
+                            gearData.setRenderRightTank(true);
+                            break;
+                        case HIDERIGHTTANK:
+                            gearData.setRenderRightTank(false);
+                            break;
+                        case SHOWFREQUENCYMODULE:
+                            gearData.setRenderFrequencyModule(true);
+                            break;
+                        case HIDEFREQUENCYMODULE:
+                            gearData.setRenderFrequencyModule(false);
+                            break;
+                        case SHOWTHERMALHELMET:
+                            gearData.setRenderThermalPadding(0, true);
+                            break;
+                        case SHOWTHERMALCHESTPLATE:
+                            gearData.setRenderThermalPadding(1, true);
+                            break;
+                        case SHOWTHERMALLEGGINGS:
+                            gearData.setRenderThermalPadding(2, true);
+                            break;
+                        case SHOWTHERMALBOOTS:
+                            gearData.setRenderThermalPadding(3, true);
+                            break;
+                        case HIDETHERMALHELMET:
+                            gearData.setRenderThermalPadding(0, false);
+                            break;
+                        case HIDETHERMALCHESTPLATE:
+                            gearData.setRenderThermalPadding(1, false);
+                            break;
+                        case HIDETHERMALLEGGINGS:
+                            gearData.setRenderThermalPadding(2, false);
+                            break;
+                        case HIDETHERMALBOOTS:
+                            gearData.setRenderThermalPadding(3, false);
+                            break;
                         default:
                             break;
                     }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/ConfigManagerCore.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/ConfigManagerCore.java
@@ -54,6 +54,7 @@ public class ConfigManagerCore {
     public static boolean disableLander;
     public static boolean recipesRequireGCAdvancedMetals = true;
     public static boolean alwaysDisplayOxygenHUD = false;
+    public static boolean disableGearRender = false;
     public static boolean allowSSatUnreachable;
     // public static int mapfactor;
     // public static int mapsize;
@@ -551,6 +552,12 @@ public class ConfigManagerCore {
             prop.comment = "Toggle this to always display the Oxygen HUD, if off it will only be shown on GC planets which require Oxygen.";
             prop.setLanguageKey("gc.configgui.alwaysDisplayOxygenHUD").setRequiresMcRestart(false);
             alwaysDisplayOxygenHUD = prop.getBoolean(false);
+            propOrder.add(prop.getName());
+
+            prop = config.get(Constants.CONFIG_CATEGORY_GENERAL, "Disable Gear Render", false);
+            prop.comment = "Toggle this to disable rendering the GC gear on your body.";
+            prop.setLanguageKey("gc.configgui.disableGearRender").setRequiresMcRestart(false);
+            disableGearRender = prop.getBoolean(false);
             propOrder.add(prop.getName());
 
             prop = config.get(Constants.CONFIG_CATEGORY_GENERAL, "Allow Stations at Unreachables", true);

--- a/src/main/java/micdoodle8/mods/galacticraft/core/wrappers/PlayerGearData.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/wrappers/PlayerGearData.java
@@ -13,6 +13,12 @@ public class PlayerGearData {
     private final int[] thermalPadding;
     private ResourceLocation parachute;
     private int frequencyModule;
+    private boolean renderMask;
+    private boolean renderGear;
+    private boolean renderLeftTank;
+    private boolean renderRightTank;
+    private boolean renderFrequencyModule;
+    private final boolean[] renderThermalPadding;
 
     public PlayerGearData(EntityPlayer player) {
         this(player, -1, -1, -1, -1, -1, new int[] { -1, -1, -1, -1 });
@@ -20,6 +26,25 @@ public class PlayerGearData {
 
     public PlayerGearData(EntityPlayer player, int mask, int gear, int leftTank, int rightTank, int frequencyModule,
             int[] thermalPadding) {
+        this(
+                player,
+                mask,
+                gear,
+                leftTank,
+                rightTank,
+                frequencyModule,
+                thermalPadding,
+                true,
+                true,
+                true,
+                true,
+                true,
+                new boolean[] { true, true, true, true });
+    }
+
+    public PlayerGearData(EntityPlayer player, int mask, int gear, int leftTank, int rightTank, int frequencyModule,
+            int[] thermalPadding, boolean renderMask, boolean renderGear, boolean renderLeftTank,
+            boolean renderRightTank, boolean renderFrequencyModule, boolean[] renderThermalPadding) {
         this.player = player;
         this.mask = mask;
         this.gear = gear;
@@ -27,6 +52,12 @@ public class PlayerGearData {
         this.rightTank = rightTank;
         this.frequencyModule = frequencyModule;
         this.thermalPadding = thermalPadding;
+        this.renderMask = renderMask;
+        this.renderGear = renderGear;
+        this.renderLeftTank = renderLeftTank;
+        this.renderRightTank = renderRightTank;
+        this.renderFrequencyModule = renderFrequencyModule;
+        this.renderThermalPadding = renderThermalPadding;
     }
 
     public int getMask() {
@@ -92,6 +123,59 @@ public class PlayerGearData {
     public void setThermalPadding(int slot, int thermalPadding) {
         if (slot >= 0 && slot < this.thermalPadding.length) {
             this.thermalPadding[slot] = thermalPadding;
+        }
+    }
+
+    public boolean getRenderMask() {
+        return renderMask;
+    }
+
+    public boolean getRenderGear() {
+        return renderGear;
+    }
+
+    public boolean getRenderLeftTank() {
+        return renderLeftTank;
+    }
+
+    public boolean getRenderRightTank() {
+        return renderRightTank;
+    }
+
+    public boolean getRenderFrequencyModule() {
+        return renderFrequencyModule;
+    }
+
+    public boolean getRenderThermalPadding(int slot) {
+        if (slot >= 0 && slot < this.renderThermalPadding.length) {
+            return this.renderThermalPadding[slot];
+        }
+        return false;
+    }
+
+    public void setRenderMask(boolean renderMask) {
+        this.renderMask = renderMask;
+    }
+
+    public void setRenderGear(boolean renderGear) {
+        this.renderGear = renderGear;
+    }
+
+    public void setRenderLeftTank(boolean renderLeftTank) {
+        this.renderLeftTank = renderLeftTank;
+    }
+
+    public void setRenderRightTank(boolean renderRightTank) {
+        this.renderRightTank = renderRightTank;
+    }
+
+    public void setRenderFrequencyModule(boolean renderFrequencyModule) {
+        this.renderFrequencyModule = renderFrequencyModule;
+    }
+
+    public void setRenderThermalPadding(int slot, boolean render) {
+        if (slot >= 0 && slot < this.renderThermalPadding.length) {
+            this.renderThermalPadding[slot] = render;
         }
     }
 

--- a/src/main/resources/assets/galacticraftcore/lang/en_GB.lang
+++ b/src/main/resources/assets/galacticraftcore/lang/en_GB.lang
@@ -742,5 +742,6 @@ gc.configgui.meteorSpawnMod=Meteor Spawn Modifier
 gc.configgui.meteorBlockDamage=Meteor Block Damage Enabled
 gc.configgui.title=Galacticraft Core Config
 gc.configgui.alwaysDisplayOxygenHUD=Always show Oxygen HUD
+gc.configgui.disableGearRender=Disable Gear Render
 
 # </file>

--- a/src/main/resources/assets/galacticraftcore/lang/en_US.lang
+++ b/src/main/resources/assets/galacticraftcore/lang/en_US.lang
@@ -753,5 +753,6 @@ gc.configgui.meteorBlockDamage=Meteor Block Damage Enabled
 gc.configgui.handfill=Enable Oxygen Tank Hand fill
 gc.configgui.disableUpdateCheck=Disable Update Check
 gc.configgui.alwaysDisplayOxygenHUD=Always show Oxygen HUD
+gc.configgui.disableGearRender=Disable Gear Render
 
 gc.configgui.title=Galacticraft Core Config


### PR DESCRIPTION
This PR fixes the Translucency II enchantment to work on the Galacticraft gear (oxygen mask, frequency module, thermal gear, tanks, etc), allowing you to hide them permanently.  Previously, applying the enchantment was possible, but did nothing.

Alternatively, I have also added a config option instead to just stop rendering of the gear completely.