### PR TITLE
Optimizes the Arc Lamp's `lightArea()`

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,6 +4,7 @@ dependencies {
     }
     implementation('com.github.GTNewHorizons:TinkersConstruct:1.13.9-GTNH:dev')
     implementation('com.github.GTNewHorizons:NotEnoughItems:2.7.29-GTNH:dev')
+    implementation('com.github.GTNewHorizons:GTNHLib:0.6.21:dev')
     api('net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev')
 
     compileOnly('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-547-GTNH:api')

--- a/src/main/java/micdoodle8/mods/galacticraft/core/GalacticraftCore.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/GalacticraftCore.java
@@ -165,7 +165,7 @@ import micdoodle8.mods.galacticraft.core.world.gen.OverworldGenerator;
         version = Constants.VERSION,
         acceptedMinecraftVersions = "[1.7.10]",
         useMetadata = true,
-        dependencies = "required-after:NotEnoughItems;before:GalaxySpace;after:IC2;after:TConstruct;after:Mantle;after:BuildCraft|Core;after:BuildCraft|Energy;after:PlayerAPI@[1.3,)",
+        dependencies = "required-after:NotEnoughItems;before:GalaxySpace;after:IC2;after:TConstruct;after:Mantle;after:BuildCraft|Core;after:BuildCraft|Energy;after:PlayerAPI@[1.3,);after:gtnhlib@[0.3.1,);",
         guiFactory = "micdoodle8.mods.galacticraft.core.client.gui.screen.ConfigGuiFactoryCore")
 public class GalacticraftCore {
 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityArclamp.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityArclamp.java
@@ -274,7 +274,9 @@ public class TileEntityArclamp extends TileEntity {
         long sideBits;
 
         for (int count = 0; count < 14; count++) {
-            for (final long packedCoord : currentLayer) {
+            LongIterator iter = currentLayer.longIterator();
+            while (iter.hasNext()) {
+                final long packedCoord = iter.nextLong();
                 side = 0;
                 sideBits = (packedCoord >> 60) & 0xF; // Extract the side bits from highest 4 bits
                 boolean allAir = true;
@@ -377,7 +379,9 @@ public class TileEntityArclamp extends TileEntity {
         // Write using the same NBT format, just unpack from longs when writing
         final NBTTagList airBlocks = new NBTTagList();
 
-        for (long packedCoord : this.airToRestore) {
+        LongIterator iterator = this.airToRestore.longIterator();
+        while (iterator.hasNext()) {
+            final long packedCoord = iterator.nextLong();
             final NBTTagCompound tag = new NBTTagCompound();
             tag.setInteger("x", CoordinatePacker.unpackX(packedCoord));
             tag.setInteger("y", CoordinatePacker.unpackY(packedCoord));

--- a/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityArclamp.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityArclamp.java
@@ -1,11 +1,12 @@
 package micdoodle8.mods.galacticraft.core.tile;
 
-import java.util.HashSet;
-import java.util.LinkedList;
+import java.lang.ref.WeakReference;
 import java.util.List;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockAir;
+import net.minecraft.crash.CrashReport;
+import net.minecraft.crash.CrashReportCategory;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityCreature;
 import net.minecraft.entity.ai.RandomPositionGenerator;
@@ -16,10 +17,18 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.pathfinding.PathNavigate;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.util.ReportedException;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
 
-import micdoodle8.mods.galacticraft.api.vector.BlockVec3;
+import com.gtnewhorizon.gtnhlib.util.CoordinatePacker;
+
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.fastutil.longs.LongList;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.blocks.GCBlocks;
 import micdoodle8.mods.galacticraft.core.network.PacketSimple;
@@ -31,12 +40,18 @@ public class TileEntityArclamp extends TileEntity {
     private int ticks = 0;
     private int sideRear = 0;
     public int facing = 0;
-    private final HashSet<BlockVec3> airToRestore = new HashSet<>();
+    private final LongSet airToRestore = new LongOpenHashSet();
     private boolean isActive = false;
     private AxisAlignedBB thisAABB;
     private Vec3 thisPos;
     private int facingSide = 0;
     public boolean updateClientFlag;
+
+    // Internal chunk cache for block access optimization using WeakReference to allow garbage collection
+    private static WeakReference<Chunk> chunkCached = new WeakReference<>(null);
+    private static int chunkCacheDim = Integer.MAX_VALUE;
+    private static int chunkCacheX = 1876000; // outside the world edge
+    private static int chunkCacheZ = 1876000; // outside the world edge
 
     @Override
     public void updateEntity() {
@@ -226,59 +241,72 @@ public class TileEntityArclamp extends TileEntity {
         final Block breatheableAirID = GCBlocks.breatheableAir;
         final Block brightAir = GCBlocks.brightAir;
         final Block brightBreatheableAir = GCBlocks.brightBreatheableAir;
-        final HashSet<BlockVec3> checked = new HashSet<>();
-        LinkedList<BlockVec3> currentLayer = new LinkedList<>();
-        LinkedList<BlockVec3> nextLayer = new LinkedList<>();
-        final BlockVec3 thisvec = new BlockVec3(this);
-        currentLayer.add(thisvec);
+        final LongSet checked = new LongOpenHashSet();
+
+        LongList currentLayer = new LongArrayList();
+        LongList nextLayer = new LongArrayList();
+        final long thisPackedCoord = CoordinatePacker.pack(this.xCoord, this.yCoord, this.zCoord);
+        currentLayer.add(thisPackedCoord);
         final World world = this.worldObj;
         final int sideskip1 = this.sideRear;
         final int sideskip2 = this.facingSide ^ 1;
         for (int i = 0; i < 6; i++) {
             if (i != sideskip1 && i != sideskip2 && i != (sideskip1 ^ 1) && i != (sideskip2 ^ 1)) {
-                final BlockVec3 onEitherSide = thisvec.newVecSide(i);
-                final Block b = onEitherSide.getBlockIDsafe_noChunkLoad(world);
+                final long neighborPackedCoord = getAdjacentPacked(thisPackedCoord, i);
+                final Block b = getBlockAtPackedCoord(world, neighborPackedCoord);
                 if (b != null && b.getLightOpacity() < 15) {
-                    currentLayer.add(onEitherSide);
+                    currentLayer.add(neighborPackedCoord);
                 }
             }
         }
-        BlockVec3 inFront = new BlockVec3(this);
+
+        long inFrontPacked = thisPackedCoord;
         for (int i = 0; i < 5; i++) {
-            inFront = inFront.newVecSide(this.facingSide).newVecSide(sideskip1 ^ 1);
-            final Block b = inFront.getBlockIDsafe_noChunkLoad(world);
+            // Move in the facing direction and then in the direction opposite to sideSkip1
+            inFrontPacked = getDoubleSidedPacked(inFrontPacked, this.facingSide, sideskip1 ^ 1);
+            final Block b = getBlockAtPackedCoord(world, inFrontPacked);
             if (b != null && b.getLightOpacity() < 15) {
-                currentLayer.add(inFront);
+                currentLayer.add(inFrontPacked);
             }
         }
 
-        int side, bits;
+        int side;
+        long sideBits;
 
         for (int count = 0; count < 14; count++) {
-            for (final BlockVec3 vec : currentLayer) {
+            for (final long packedCoord : currentLayer) {
                 side = 0;
-                bits = vec.sideDoneBits;
+                sideBits = (packedCoord >> 60) & 0xF; // Extract the side bits from highest 4 bits
                 boolean allAir = true;
+
                 do {
                     // Skip the side which this was entered from
                     // and never go 'backwards'
-                    if ((bits & 1 << side) == 0) {
-                        final BlockVec3 sideVec = vec.newVecSide(side);
+                    if ((sideBits & (1 << side)) == 0) {
+                        // Create adjacent packed coordinate with side info
+                        final long sidePackedCoord = getAdjacentPacked(packedCoord, side);
 
-                        if (!checked.contains(sideVec)) {
-                            checked.add(sideVec);
+                        if (!checked.contains(sidePackedCoord)) {
+                            checked.add(sidePackedCoord);
 
-                            final Block b = sideVec.getBlockIDsafe_noChunkLoad(world);
+                            // Get coordinates for block access
+                            final int sideX = CoordinatePacker.unpackX(sidePackedCoord);
+                            final int sideY = CoordinatePacker.unpackY(sidePackedCoord);
+                            final int sideZ = CoordinatePacker.unpackZ(sidePackedCoord);
+
+                            // Get block at the coordinates without loading chunks
+                            final Block b = getBlockAtPackedCoord(world, sidePackedCoord);
+
                             if (b instanceof BlockAir) {
                                 if (side != sideskip1 && side != sideskip2) {
-                                    nextLayer.add(sideVec);
+                                    nextLayer.add(sidePackedCoord);
                                 }
                             } else {
                                 allAir = false;
-                                if (b != null && b.getLightOpacity(world, sideVec.x, sideVec.y, sideVec.z) == 0
+                                if (b != null && b.getLightOpacity(world, sideX, sideY, sideZ) == 0
                                         && side != sideskip1
                                         && side != sideskip2) {
-                                    nextLayer.add(sideVec);
+                                    nextLayer.add(sidePackedCoord);
                                 }
                             }
                         }
@@ -287,21 +315,31 @@ public class TileEntityArclamp extends TileEntity {
                 } while (side < 6);
 
                 if (!allAir) {
-                    final Block id = vec.getBlockIDsafe_noChunkLoad(world);
+                    // Get coordinates for current position
+                    final int x = CoordinatePacker.unpackX(packedCoord);
+                    final int y = CoordinatePacker.unpackY(packedCoord);
+                    final int z = CoordinatePacker.unpackZ(packedCoord);
+
+                    // Get block at current position
+                    final Block id = getBlockAtPackedCoord(world, packedCoord);
+
                     if (Blocks.air == id) {
-                        world.setBlock(vec.x, vec.y, vec.z, brightAir, 0, 2);
-                        this.airToRestore.add(vec);
+                        world.setBlock(x, y, z, brightAir, 0, 2);
+                        // Since airToRestore is now a LongSet, we just add the packed coordinate
+                        this.airToRestore.add(packedCoord);
                         this.markDirty();
                     } else if (id == breatheableAirID) {
-                        world.setBlock(vec.x, vec.y, vec.z, brightBreatheableAir, 0, 2);
-                        this.airToRestore.add(vec);
+                        world.setBlock(x, y, z, brightBreatheableAir, 0, 2);
+                        // Since airToRestore is now a LongSet, we just add the packed coordinate
+                        this.airToRestore.add(packedCoord);
                         this.markDirty();
                     }
                 }
             }
+
             currentLayer = nextLayer;
-            nextLayer = new LinkedList<>();
-            if (currentLayer.size() == 0) {
+            nextLayer = new LongArrayList(); // Use LongArrayList for packed longs
+            if (currentLayer.isEmpty()) {
                 break;
             }
         }
@@ -315,12 +353,16 @@ public class TileEntityArclamp extends TileEntity {
         this.updateClientFlag = true;
 
         this.airToRestore.clear();
+
+        // Use the same NBT format structure, just convert to packed longs internally
         final NBTTagList airBlocks = nbt.getTagList("AirBlocks", 10);
         if (airBlocks.tagCount() > 0) {
             for (int j = airBlocks.tagCount() - 1; j >= 0; j--) {
-                final NBTTagCompound tag1 = airBlocks.getCompoundTagAt(j);
-                if (tag1 != null) {
-                    this.airToRestore.add(BlockVec3.readFromNBT(tag1));
+                final NBTTagCompound tag = airBlocks.getCompoundTagAt(j);
+                if (tag != null) {
+                    long packedCoord = CoordinatePacker
+                            .pack(tag.getInteger("x"), tag.getInteger("y"), tag.getInteger("z"));
+                    this.airToRestore.add(packedCoord);
                 }
             }
         }
@@ -332,13 +374,17 @@ public class TileEntityArclamp extends TileEntity {
 
         nbt.setInteger("Facing", this.facing);
 
+        // Write using the same NBT format, just unpack from longs when writing
         final NBTTagList airBlocks = new NBTTagList();
 
-        for (final BlockVec3 vec : this.airToRestore) {
+        for (long packedCoord : this.airToRestore) {
             final NBTTagCompound tag = new NBTTagCompound();
-            vec.writeToNBT(tag);
+            tag.setInteger("x", CoordinatePacker.unpackX(packedCoord));
+            tag.setInteger("y", CoordinatePacker.unpackY(packedCoord));
+            tag.setInteger("z", CoordinatePacker.unpackZ(packedCoord));
             airBlocks.appendTag(tag);
         }
+
         nbt.setTag("AirBlocks", airBlocks);
     }
 
@@ -362,20 +408,206 @@ public class TileEntityArclamp extends TileEntity {
     private void revertAir() {
         final Block brightAir = GCBlocks.brightAir;
         final Block brightBreatheableAir = GCBlocks.brightBreatheableAir;
-        for (final BlockVec3 vec : this.airToRestore) {
-            final Block b = vec.getBlock(this.worldObj);
+
+        LongIterator iterator = this.airToRestore.longIterator();
+        while (iterator.hasNext()) {
+            final long packedCoord = iterator.nextLong();
+
+            // Unpack coordinates
+            final int x = CoordinatePacker.unpackX(packedCoord);
+            final int y = CoordinatePacker.unpackY(packedCoord);
+            final int z = CoordinatePacker.unpackZ(packedCoord);
+
+            // Get the block at these coordinates
+            final Block b = this.worldObj.getBlock(x, y, z);
+
             if (b == brightAir) {
-                this.worldObj.setBlock(vec.x, vec.y, vec.z, Blocks.air, 0, 2);
+                this.worldObj.setBlock(x, y, z, Blocks.air, 0, 2);
             } else if (b == brightBreatheableAir) {
-                this.worldObj.setBlock(vec.x, vec.y, vec.z, GCBlocks.breatheableAir, 0, 2);
+                this.worldObj.setBlock(x, y, z, GCBlocks.breatheableAir, 0, 2);
                 // No block update - not necessary for changing air to air, also must not
                 // trigger a sealer edge check
             }
         }
+
         this.airToRestore.clear();
     }
 
     public boolean getEnabled() {
         return !RedstoneUtil.isBlockReceivingRedstone(this.worldObj, this.xCoord, this.yCoord, this.zCoord);
     }
+
+    /**
+     * Creates a packed coordinate for a position adjacent to the given packed coordinate in the specified direction.
+     * Also embeds side information in the high bits for efficient traversal.
+     *
+     * @param packedCoord The original packed coordinate
+     * @param side        The side (0-5) to move toward
+     * @return A new packed coordinate with side information
+     */
+    private long getAdjacentPacked(long packedCoord, int side) {
+        int x = CoordinatePacker.unpackX(packedCoord);
+        int y = CoordinatePacker.unpackY(packedCoord);
+        int z = CoordinatePacker.unpackZ(packedCoord);
+
+        // Extract existing side bits to preserve them
+        final long existingSideBits = packedCoord & 0xF000000000000000L;
+
+        // Store side info in high bits (4 bits): which side this position came from
+        // Use 4 of the 12 bits allocated for y and side info, leaving 8 bits for y coordinates
+        // Use bit pattern: (1 << (side ^ 1)) to mark the opposite side as done
+        // This creates a bitmask with the bit for the opposite side set to 1
+        final long newSideBits = ((long) (1 << (side ^ 1)) + ((long) side << 6)) << 60;
+
+        // Combine with existing side bits (preserving any previously set sides)
+        long sideBits = existingSideBits | newSideBits;
+
+        switch (side) {
+            case 0:
+                y--;
+                break;
+            case 1:
+                y++;
+                break;
+            case 2:
+                z--;
+                break;
+            case 3:
+                z++;
+                break;
+            case 4:
+                x--;
+                break;
+            case 5:
+                x++;
+                break;
+        }
+
+        // Pack coordinates according to the new scheme (26 bits x, 26 bits z, 8 bits y)
+        // and combine with the side bits in the highest 4 bits
+        return CoordinatePacker.pack(x, y, z) | sideBits;
+    }
+
+    /**
+     * Gets the block at the specified packed coordinate position without forcing chunk load. - Borrowed and adapted
+     * from BlockVec3
+     *
+     * @param world       The world
+     * @param packedCoord The packed coordinate
+     * @return The block at the position, or null if the coordinate is invalid or chunk isn't loaded
+     */
+    private Block getBlockAtPackedCoord(World world, long packedCoord) {
+        // Clear the high bits (where side information is stored) to get only coordinate data
+        final long coordBits = packedCoord & 0x0FFFFFFFFFFFFFFFL;
+
+        int x = CoordinatePacker.unpackX(coordBits);
+        int y = CoordinatePacker.unpackY(coordBits);
+        int z = CoordinatePacker.unpackZ(coordBits);
+
+        if (y < 0 || y >= 256) {
+            return null;
+        }
+
+        final int chunkx = x >> 4;
+        final int chunkz = z >> 4;
+        try {
+            if (world.getChunkProvider().chunkExists(chunkx, chunkz)) {
+                // In a typical inner loop, 80% of the time consecutive calls to
+                // this will be within the same chunk
+                Chunk cached = chunkCached.get();
+                if (chunkCacheX == chunkx && chunkCacheZ == chunkz
+                        && chunkCacheDim == world.provider.dimensionId
+                        && cached != null
+                        && cached.isChunkLoaded) {
+                    return cached.getBlock(x & 15, y, z & 15);
+                }
+
+                Chunk chunk = world.getChunkFromChunkCoords(chunkx, chunkz);
+                chunkCached = new WeakReference<>(chunk);
+                chunkCacheDim = world.provider.dimensionId;
+                chunkCacheX = chunkx;
+                chunkCacheZ = chunkz;
+                return chunk.getBlock(x & 15, y, z & 15);
+            }
+            // Chunk doesn't exist - meaning, it is not loaded
+            return Blocks.bedrock;
+        } catch (final Throwable throwable) {
+            final CrashReport crashreport = CrashReport
+                    .makeCrashReport(throwable, "Arclamp thread: Exception getting block type in world");
+            final CrashReportCategory crashreportcategory = crashreport.makeCategory("Requested block coordinates");
+            crashreportcategory.addCrashSection("Location", CrashReportCategory.getLocationInfo(x, y, z));
+            throw new ReportedException(crashreport);
+        }
+    }
+
+    /**
+     * Creates a packed coordinate that is moved in two directions from the original coordinate. Useful for creating
+     * coordinates that are moved in multiple directions.
+     *
+     * @param packedCoord The original packed coordinate
+     * @param firstSide   The first direction to move in
+     * @param secondSide  The second direction to move in
+     * @return A new packed coordinate moved in both directions with side info
+     */
+    private long getDoubleSidedPacked(long packedCoord, int firstSide, int secondSide) {
+        int x = CoordinatePacker.unpackX(packedCoord);
+        int y = CoordinatePacker.unpackY(packedCoord);
+        int z = CoordinatePacker.unpackZ(packedCoord);
+
+        // Apply first side movement
+        switch (firstSide) {
+            case 0:
+                y--;
+                break;
+            case 1:
+                y++;
+                break;
+            case 2:
+                z--;
+                break;
+            case 3:
+                z++;
+                break;
+            case 4:
+                x--;
+                break;
+            case 5:
+                x++;
+                break;
+        }
+
+        // Apply second side movement
+        switch (secondSide) {
+            case 0:
+                y--;
+                break;
+            case 1:
+                y++;
+                break;
+            case 2:
+                z--;
+                break;
+            case 3:
+                z++;
+                break;
+            case 4:
+                x--;
+                break;
+            case 5:
+                x++;
+                break;
+        }
+
+        // Extract existing side bits to preserve them
+        long existingSideBits = packedCoord & 0xF000000000000000L;
+
+        // Store first side info in high bits (4 bits)
+        long newSideBits = ((long) (1 << (firstSide ^ 1)) + ((long) firstSide << 6)) << 60;
+
+        // Combine with existing side bits
+        long sideBits = existingSideBits | newSideBits;
+
+        return CoordinatePacker.pack(x, y, z) | sideBits;
+    }
+
 }


### PR DESCRIPTION
This showed up on a profile by from Adam and it annoyed me
![Screenshot_20250508_082237](https://github.com/user-attachments/assets/1726966e-338e-420c-949c-c43e309e97c8)


From a local profile in dev - 3minutes, a few hundred arc lamps:
![image](https://github.com/user-attachments/assets/5c245bfd-a5ad-491f-8225-e53900ef4ca1)
![image](https://github.com/user-attachments/assets/e6109844-86a8-400b-b5ae-a33e8b4e86e8)


After:
![image](https://github.com/user-attachments/assets/8bd3f874-9fb0-4a57-a889-601c9309df6e)
![image](https://github.com/user-attachments/assets/3ae3d0c1-81e9-4f2d-a4a1-a9bdedf21d87)
