### PR TITLE
Gas name fix

### DIFF
--- a/src/main/resources/assets/galacticraftasteroids/lang/en_US.lang
+++ b/src/main/resources/assets/galacticraftasteroids/lang/en_US.lang
@@ -56,13 +56,13 @@ item.canister.liquidArgon.name=Liquid       #short name for Liquid Argon content
 item.emptyGasCanister.name=Empty Gas Canister
 
 # FLUIDS AND GASES
-fluid.methane=Methane Gas
-fluid.oxygen=Oxygen Gas
-fluid.nitrogen=Nitrogen Gas
-fluid.hydrogen=Hydrogen Gas
-fluid.carbondioxide=CO2 Gas
-fluid.helium=Helium Gas
-fluid.argon=Argon Gas
+fluid.methane=Methane
+fluid.oxygen=Oxygen
+fluid.nitrogen=Nitrogen
+fluid.hydrogen=Hydrogen
+fluid.carbondioxide=Carbon Dioxide
+fluid.helium=Helium
+fluid.argon=Argon
 fluid.atmosphericgases=Atmospheric Gases
 fluid.liquidmethane=Liquid Methane
 fluid.liquidoxygen=Liquid Oxygen


### PR DESCRIPTION
Closes [Rename CO2 Gas to Carbon Dioxide #19961](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19961), and renames Galacticraft Gases so they lose the "gas" postfix