### PR TITLE
Remove duplicate parachute dyeing recipes

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemParaChute.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemParaChute.java
@@ -129,45 +129,6 @@ public class ItemParaChute extends Item {
     // return 0;
     // }
 
-    public static int getParachuteDamageValueFromDye(int meta) {
-        switch (meta) {
-            case 0:
-                return 1;
-            case 1:
-                return 13;
-            case 2:
-                return 7;
-            case 3:
-                return 4;
-            case 4:
-                return 5;
-            case 5:
-                return 12;
-            case 6:
-                return 14;
-            case 7:
-                return 8;
-            case 8:
-                return 6;
-            case 9:
-                return 11;
-            case 10:
-                return 3;
-            case 11:
-                return 15;
-            case 12:
-                return 2;
-            case 13:
-                return 9;
-            case 14:
-                return 10;
-            case 15:
-                return 0;
-        }
-
-        return -1;
-    }
-
     @Override
     @SideOnly(Side.CLIENT)
     public EnumRarity getRarity(ItemStack par1ItemStack) {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/recipe/RecipeManagerGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/recipe/RecipeManagerGC.java
@@ -26,7 +26,6 @@ import micdoodle8.mods.galacticraft.core.entities.EntityBuggy;
 import micdoodle8.mods.galacticraft.core.entities.EntityTier1Rocket;
 import micdoodle8.mods.galacticraft.core.items.GCItems;
 import micdoodle8.mods.galacticraft.core.items.ItemBasic;
-import micdoodle8.mods.galacticraft.core.items.ItemParaChute;
 import micdoodle8.mods.galacticraft.core.util.CompatibilityManager;
 import micdoodle8.mods.galacticraft.core.util.ConfigManagerCore;
 import micdoodle8.mods.galacticraft.core.util.GCLog;
@@ -630,13 +629,6 @@ public class RecipeManagerGC {
         RecipeUtil.addRecipe(
                 new ItemStack(GCItems.flag),
                 new Object[] { "XYY", "XYY", "X  ", 'X', GCItems.flagPole, 'Y', GCItems.canvas });
-
-        for (int var2 = 0; var2 < 16; ++var2) {
-            CraftingManager.getInstance().addShapelessRecipe(
-                    new ItemStack(GCItems.parachute, 1, ItemParaChute.getParachuteDamageValueFromDye(var2)),
-                    new ItemStack(Items.dye, 1, var2),
-                    new ItemStack(GCItems.parachute, 1, 0));
-        }
 
         RecipeUtil.addRecipe(
                 new ItemStack(Blocks.lit_pumpkin),


### PR DESCRIPTION
Removes parachute dyeing recipes that are made duplicate by: https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1431