### PR TITLE
Fix liquid Nitrogen temperature

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/AsteroidsModule.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/AsteroidsModule.java
@@ -126,7 +126,7 @@ public class AsteroidsModule implements IPlanetsModule {
         // http://science.nasa.gov/science-news/science-at-nasa/2005/25feb_titan2/
         AsteroidsModule.fluidLiquidOxygen = this.registerFluid("liquidoxygen", 1141, 140, 90, false);
         AsteroidsModule.fluidOxygenGas = this.registerFluid("oxygen", 1, 13, 295, true);
-        AsteroidsModule.fluidLiquidNitrogen = this.registerFluid("liquidnitrogen", 808, 130, 90, false);
+        AsteroidsModule.fluidLiquidNitrogen = this.registerFluid("liquidnitrogen", 808, 130, 77, false);
         AsteroidsModule.fluidNitrogenGas = this.registerFluid("nitrogen", 1, 12, 295, true);
         this.registerFluid("carbondioxide", 2, 20, 295, true);
         this.registerFluid("hydrogen", 1, 1, 295, true);


### PR DESCRIPTION
Based on the [GT5U](https://github.com/GTNewHorizons/GT5-Unofficial/blob/ee07a0788acf731fe65562ee6135e98bf6b32cc1/src/main/java/gregtech/loaders/preload/LoaderGTBlockFluid.java#L919), the property of liquid Nitrogen in real life, and a thorough verification of the GT:NH repositories and in-game behavior, we can confirm that this issue affects GT5U's fluid registration and should be fixed.