### PR TITLE
Fix coordinate packing bug in ArcLamp

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,3 +3,7 @@
 plugins {
     id 'com.gtnewhorizons.gtnhconvention'
 }
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,4 +1,6 @@
 dependencies {
+    testImplementation('org.junit.jupiter:junit-jupiter:5.11.0')
+
     implementation('com.github.GTNewHorizons:GT5-Unofficial:5.09.52.85:dev') {
         exclude group: "com.github.GTNewHorizons", module: "Galacticraft"
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/RelativeCoordinatePacker.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/RelativeCoordinatePacker.java
@@ -1,37 +1,39 @@
 package micdoodle8.mods.galacticraft.core.util;
 
 /**
- * Packs relative coordinates into an int with optional side bits. Layout: [8 unused][6 side bits][6 Y][6 Z][6 X]
+ * Packs relative coordinates into an int with optional side bits. Layout: [6 side bits][8 Y][9 Z][9 X]
  * <p>
- * Valid range for each coordinate: -32 to +31 (6-bit signed). Values outside this range will silently wrap due to
- * masking.
+ * Valid range: X/Z: -256 to +255 (9-bit signed), Y: -128 to +127 (8-bit signed).
+ * Values outside this range will silently wrap due to masking.
  */
 public final class RelativeCoordinatePacker {
 
-    private static final int COORD_MASK = 0x3F;
-    private static final int SIDE_SHIFT = 18;
-    public static final int COORD_ONLY_MASK = 0x3FFFF;
+    private static final int XZ_MASK = 0x1FF;
+    private static final int Y_MASK = 0xFF;
+    private static final int SIDE_MASK = 0x3F;
+    private static final int SIDE_SHIFT = 26;
+    public static final int COORD_ONLY_MASK = 0x3FFFFFF;
 
     private RelativeCoordinatePacker() {}
 
     public static int pack(int relX, int relY, int relZ) {
-        return (relX & COORD_MASK) | ((relZ & COORD_MASK) << 6) | ((relY & COORD_MASK) << 12);
+        return (relX & XZ_MASK) | ((relZ & XZ_MASK) << 9) | ((relY & Y_MASK) << 18);
     }
 
     public static int unpackX(int packed) {
-        return (packed << 26) >> 26;
+        return (packed << 23) >> 23;
     }
 
     public static int unpackZ(int packed) {
-        return (packed << 20) >> 26;
+        return (packed << 14) >> 23;
     }
 
     public static int unpackY(int packed) {
-        return (packed << 14) >> 26;
+        return (packed << 6) >> 24;
     }
 
     public static int getSideBits(int packed) {
-        return (packed >>> SIDE_SHIFT) & COORD_MASK;
+        return (packed >>> SIDE_SHIFT) & SIDE_MASK;
     }
 
     public static int withSideBit(int packed, int side) {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/RelativeCoordinatePacker.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/RelativeCoordinatePacker.java
@@ -3,33 +3,53 @@ package micdoodle8.mods.galacticraft.core.util;
 /**
  * Packs relative coordinates into an int with optional side bits. Layout: [6 side bits][8 Y][9 Z][9 X]
  * <p>
- * Valid range: X/Z: -256 to +255 (9-bit signed), Y: -128 to +127 (8-bit signed).
- * Values outside this range will silently wrap due to masking.
+ * Valid range: X/Z: -256 to +255 (9-bit signed), Y: -128 to +127 (8-bit signed). Values outside this range will
+ * silently wrap due to masking.
  */
 public final class RelativeCoordinatePacker {
 
-    private static final int XZ_MASK = 0x1FF;
-    private static final int Y_MASK = 0xFF;
-    private static final int SIDE_MASK = 0x3F;
-    private static final int SIDE_SHIFT = 26;
-    public static final int COORD_ONLY_MASK = 0x3FFFFFF;
+    // Bit widths for each field
+    private static final int X_BITS = 9;
+    private static final int Z_BITS = 9;
+    private static final int Y_BITS = 8;
+    private static final int SIDE_BITS = 6;
+
+    // Bit positions where each field starts
+    private static final int Z_SHIFT = X_BITS;
+    private static final int Y_SHIFT = X_BITS + Z_BITS;
+    private static final int SIDE_SHIFT = X_BITS + Z_BITS + Y_BITS;
+
+    // Masks to isolate each field
+    private static final int XZ_MASK = (1 << X_BITS) - 1;
+    private static final int Y_MASK = (1 << Y_BITS) - 1;
+    private static final int SIDE_MASK = (1 << SIDE_BITS) - 1;
+
+    // Mask for coordinate-only portion (excludes side bits)
+    public static final int COORD_ONLY_MASK = (1 << SIDE_SHIFT) - 1;
+
+    // Sign extension: shift left to put sign bit at bit 31, then arithmetic shift right
+    private static final int X_SIGN_LEFT = 32 - X_BITS;
+    private static final int Z_SIGN_LEFT = 32 - (X_BITS + Z_BITS);
+    private static final int Y_SIGN_LEFT = 32 - (X_BITS + Z_BITS + Y_BITS);
+    private static final int XZ_SIGN_RIGHT = 32 - X_BITS;
+    private static final int Y_SIGN_RIGHT = 32 - Y_BITS;
 
     private RelativeCoordinatePacker() {}
 
     public static int pack(int relX, int relY, int relZ) {
-        return (relX & XZ_MASK) | ((relZ & XZ_MASK) << 9) | ((relY & Y_MASK) << 18);
+        return (relX & XZ_MASK) | ((relZ & XZ_MASK) << Z_SHIFT) | ((relY & Y_MASK) << Y_SHIFT);
     }
 
     public static int unpackX(int packed) {
-        return (packed << 23) >> 23;
+        return (packed << X_SIGN_LEFT) >> XZ_SIGN_RIGHT;
     }
 
     public static int unpackZ(int packed) {
-        return (packed << 14) >> 23;
+        return (packed << Z_SIGN_LEFT) >> XZ_SIGN_RIGHT;
     }
 
     public static int unpackY(int packed) {
-        return (packed << 6) >> 24;
+        return (packed << Y_SIGN_LEFT) >> Y_SIGN_RIGHT;
     }
 
     public static int getSideBits(int packed) {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/RelativeCoordinatePacker.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/RelativeCoordinatePacker.java
@@ -1,0 +1,44 @@
+package micdoodle8.mods.galacticraft.core.util;
+
+/**
+ * Packs relative coordinates into an int with optional side bits. Layout: [8 unused][6 side bits][6 Y][6 Z][6 X]
+ * <p>
+ * Valid range for each coordinate: -32 to +31 (6-bit signed). Values outside this range will silently wrap due to
+ * masking.
+ */
+public final class RelativeCoordinatePacker {
+
+    private static final int COORD_MASK = 0x3F;
+    private static final int SIDE_SHIFT = 18;
+    public static final int COORD_ONLY_MASK = 0x3FFFF;
+
+    private RelativeCoordinatePacker() {}
+
+    public static int pack(int relX, int relY, int relZ) {
+        return (relX & COORD_MASK) | ((relZ & COORD_MASK) << 6) | ((relY & COORD_MASK) << 12);
+    }
+
+    public static int unpackX(int packed) {
+        return (packed << 26) >> 26;
+    }
+
+    public static int unpackZ(int packed) {
+        return (packed << 20) >> 26;
+    }
+
+    public static int unpackY(int packed) {
+        return (packed << 14) >> 26;
+    }
+
+    public static int getSideBits(int packed) {
+        return (packed >>> SIDE_SHIFT) & COORD_MASK;
+    }
+
+    public static int withSideBit(int packed, int side) {
+        return packed | (1 << (SIDE_SHIFT + side));
+    }
+
+    public static int coordOnly(int packed) {
+        return packed & COORD_ONLY_MASK;
+    }
+}

--- a/src/test/java/micdoodle8/mods/galacticraft/core/util/RelativeCoordinatePackerTest.java
+++ b/src/test/java/micdoodle8/mods/galacticraft/core/util/RelativeCoordinatePackerTest.java
@@ -8,8 +8,15 @@ public class RelativeCoordinatePackerTest {
 
     @Test
     void testPackUnpackRoundTrip() {
-        int[][] coords = { { 0, 0, 0 }, { 1, 0, 0 }, { 0, 1, 0 }, { 0, 0, 1 }, { -1, 0, 0 }, { 0, -1, 0 }, { 0, 0, -1 },
-                { -1, -1, -1 }, { 31, 31, 31 }, { -32, -32, -32 }, { -15, 10, -20 }, };
+        // X/Z: 9-bit signed (-256 to +255), Y: 8-bit signed (-128 to +127)
+        int[][] coords = {
+                { 0, 0, 0 }, { 1, 0, 0 }, { 0, 1, 0 }, { 0, 0, 1 },
+                { -1, 0, 0 }, { 0, -1, 0 }, { 0, 0, -1 }, { -1, -1, -1 },
+                { 31, 31, 31 }, { -32, -32, -32 }, { -15, 10, -20 },
+                // Extended range tests
+                { 255, 127, 255 }, { -256, -128, -256 },
+                { 100, -50, -200 }, { -200, 100, 150 },
+        };
         for (int[] c : coords) {
             int packed = RelativeCoordinatePacker.pack(c[0], c[1], c[2]);
             assertEquals(c[0], RelativeCoordinatePacker.unpackX(packed), "X for " + c[0]);

--- a/src/test/java/micdoodle8/mods/galacticraft/core/util/RelativeCoordinatePackerTest.java
+++ b/src/test/java/micdoodle8/mods/galacticraft/core/util/RelativeCoordinatePackerTest.java
@@ -1,0 +1,41 @@
+package micdoodle8.mods.galacticraft.core.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class RelativeCoordinatePackerTest {
+
+    @Test
+    void testPackUnpackRoundTrip() {
+        int[][] coords = { { 0, 0, 0 }, { 1, 0, 0 }, { 0, 1, 0 }, { 0, 0, 1 }, { -1, 0, 0 }, { 0, -1, 0 }, { 0, 0, -1 },
+                { -1, -1, -1 }, { 31, 31, 31 }, { -32, -32, -32 }, { -15, 10, -20 }, };
+        for (int[] c : coords) {
+            int packed = RelativeCoordinatePacker.pack(c[0], c[1], c[2]);
+            assertEquals(c[0], RelativeCoordinatePacker.unpackX(packed), "X for " + c[0]);
+            assertEquals(c[1], RelativeCoordinatePacker.unpackY(packed), "Y for " + c[1]);
+            assertEquals(c[2], RelativeCoordinatePacker.unpackZ(packed), "Z for " + c[2]);
+        }
+    }
+
+    @Test
+    void testSideBitsDoNotCorruptCoordinates() {
+        // Reproduces the original bug: coords must survive adding side bits
+        int packed = RelativeCoordinatePacker.pack(1, 20, 0);
+        for (int side = 0; side < 6; side++) {
+            packed = RelativeCoordinatePacker.withSideBit(packed, side);
+        }
+        assertEquals(1, RelativeCoordinatePacker.unpackX(packed));
+        assertEquals(20, RelativeCoordinatePacker.unpackY(packed));
+        assertEquals(0, RelativeCoordinatePacker.unpackZ(packed));
+        assertEquals(0x3F, RelativeCoordinatePacker.getSideBits(packed));
+    }
+
+    @Test
+    void testCoordOnlyForHashSet() {
+        // Same coord reached from different sides should match in hash set
+        int packed1 = RelativeCoordinatePacker.withSideBit(RelativeCoordinatePacker.pack(5, -3, 10), 0);
+        int packed2 = RelativeCoordinatePacker.withSideBit(RelativeCoordinatePacker.pack(5, -3, 10), 3);
+        assertEquals(RelativeCoordinatePacker.coordOnly(packed1), RelativeCoordinatePacker.coordOnly(packed2));
+    }
+}

--- a/src/test/java/micdoodle8/mods/galacticraft/core/util/RelativeCoordinatePackerTest.java
+++ b/src/test/java/micdoodle8/mods/galacticraft/core/util/RelativeCoordinatePackerTest.java
@@ -9,14 +9,10 @@ public class RelativeCoordinatePackerTest {
     @Test
     void testPackUnpackRoundTrip() {
         // X/Z: 9-bit signed (-256 to +255), Y: 8-bit signed (-128 to +127)
-        int[][] coords = {
-                { 0, 0, 0 }, { 1, 0, 0 }, { 0, 1, 0 }, { 0, 0, 1 },
-                { -1, 0, 0 }, { 0, -1, 0 }, { 0, 0, -1 }, { -1, -1, -1 },
-                { 31, 31, 31 }, { -32, -32, -32 }, { -15, 10, -20 },
+        int[][] coords = { { 0, 0, 0 }, { 1, 0, 0 }, { 0, 1, 0 }, { 0, 0, 1 }, { -1, 0, 0 }, { 0, -1, 0 }, { 0, 0, -1 },
+                { -1, -1, -1 }, { 31, 31, 31 }, { -32, -32, -32 }, { -15, 10, -20 },
                 // Extended range tests
-                { 255, 127, 255 }, { -256, -128, -256 },
-                { 100, -50, -200 }, { -200, 100, 150 },
-        };
+                { 255, 127, 255 }, { -256, -128, -256 }, { 100, -50, -200 }, { -200, 100, 150 }, };
         for (int[] c : coords) {
             int packed = RelativeCoordinatePacker.pack(c[0], c[1], c[2]);
             assertEquals(c[0], RelativeCoordinatePacker.unpackX(packed), "X for " + c[0]);


### PR DESCRIPTION
* Adds a small RelativeCoordinatePacker w/ tests
* Use relative offsets + side in ints instead of a long from CoordinatePacker
* Fixes a bug where lightArea wouldn't re-add existing bright air so things wouldn't get cleaned up when broken properly