### PR TITLE
Fix the oxygen usage when entering water

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/OxygenUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/OxygenUtil.java
@@ -433,53 +433,64 @@ public class OxygenUtil {
      * @param player The player to check and apply the effect to.
      */
     public static void applyWaterBreathingEffect(EntityPlayerMP player) {
-        // Check if the players head is actually in water (not just their feet)
-        final double eyeY = player.posY + player.getEyeHeight();
-        final int headBlockX = MathHelper.floor_double(player.posX);
-        final int headBlockY = MathHelper.floor_double(eyeY);
-        final int headBlockZ = MathHelper.floor_double(player.posZ);
-        Block blockAtHead = player.worldObj.getBlock(headBlockX, headBlockY, headBlockZ);
-        Material materialAtHead = blockAtHead.getMaterial();
-        if (materialAtHead != Material.water) {
+        if (!isHeadInWater(player)) {
             return;
         }
 
-        // Check if the player already has water breathing from another source
-        if (player.isPotionActive(Potion.waterBreathing)) {
-            PotionEffect existingEffect = player.getActivePotionEffect(Potion.waterBreathing);
-            if (existingEffect != null && (existingEffect.getDuration() > 220 || existingEffect.getAmplifier() > 0)) {
-                return;
-            }
+        if (hasSufficientWaterBreathing(player)) {
+            return;
         }
 
-        if (hasValidOxygenSetup(player)) {
-            GCPlayerStats stats = GCPlayerStats.get(player);
-            ItemStack tankInSlot1 = stats.extendedInventory.getStackInSlot(2);
-            ItemStack tankInSlot2 = stats.extendedInventory.getStackInSlot(3);
-
-            boolean hasOxygenAvailable = false;
-
-            if (tankInSlot1 != null && tankInSlot1.getItem() instanceof ItemOxygenTank
-                    && tankInSlot1.getMaxDamage() - tankInSlot1.getItemDamage() > 0) {
-                hasOxygenAvailable = true;
-            } else if (tankInSlot2 != null && tankInSlot2.getItem() instanceof ItemOxygenTank
-                    && tankInSlot2.getMaxDamage() - tankInSlot2.getItemDamage() > 0) {
-                        hasOxygenAvailable = true;
-                    }
-
-            if (hasOxygenAvailable) {
-                // Apply the water breathing effect
-                player.addPotionEffect(new PotionEffect(Potion.waterBreathing.id, 220, 0, true));
-
-                // Consume oxygen
-                if (tankInSlot1 != null && tankInSlot1.getItem() instanceof ItemOxygenTank
-                        && tankInSlot1.getMaxDamage() - tankInSlot1.getItemDamage() > 0) {
-                    tankInSlot1.damageItem(1, player);
-                } else if (tankInSlot2 != null && tankInSlot2.getItem() instanceof ItemOxygenTank
-                        && tankInSlot2.getMaxDamage() - tankInSlot2.getItemDamage() > 0) {
-                            tankInSlot2.damageItem(1, player);
-                        }
-            }
+        if (!hasValidOxygenSetup(player)) {
+            return;
         }
+
+        GCPlayerStats stats = GCPlayerStats.get(player);
+        ItemStack tank1 = stats.extendedInventory.getStackInSlot(2);
+        ItemStack tank2 = stats.extendedInventory.getStackInSlot(3);
+
+        if (!hasOxygen(tank1) && !hasOxygen(tank2)) {
+            return;
+        }
+
+        // Apply effect
+        player.addPotionEffect(new PotionEffect(Potion.waterBreathing.id, 220, 0, true));
+
+        // Consume oxygen (prefer first tank)
+        if (!consumeOxygen(tank1, player)) {
+            consumeOxygen(tank2, player);
+        }
+    }
+
+    private static boolean isHeadInWater(EntityPlayerMP player) {
+        double eyeY = player.posY + player.getEyeHeight();
+        int x = MathHelper.floor_double(player.posX);
+        int y = MathHelper.floor_double(eyeY);
+        int z = MathHelper.floor_double(player.posZ);
+
+        return player.worldObj.getBlock(x, y, z).getMaterial() == Material.water;
+    }
+
+    private static boolean hasSufficientWaterBreathing(EntityPlayerMP player) {
+        if (!player.isPotionActive(Potion.waterBreathing)) {
+            return false;
+        }
+
+        PotionEffect effect = player.getActivePotionEffect(Potion.waterBreathing);
+        return effect != null && (effect.getDuration() > 220 || effect.getAmplifier() > 0);
+    }
+
+    private static boolean hasOxygen(ItemStack tank) {
+        return tank != null && tank.getItem() instanceof ItemOxygenTank
+                && tank.getMaxDamage() - tank.getItemDamage() > 0;
+    }
+
+    private static boolean consumeOxygen(ItemStack tank, EntityPlayerMP player) {
+        if (!hasOxygen(tank)) {
+            return false;
+        }
+
+        tank.damageItem(1, player);
+        return true;
     }
 }


### PR DESCRIPTION
currently, oxygen gets consumed as soon as the player touches water, not just when he actually submerges. Also, oxygen would be consumed if the player already had the water breathing effect active. This PR fixes both of these.
Tested in dev env and seemed to work perfectly fine.
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20451