### PR TITLE
Create GalacticraftModels class to avoid duplicate models registration

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/GalacticraftModels.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/GalacticraftModels.java
@@ -1,0 +1,118 @@
+package micdoodle8.mods.galacticraft.core.client;
+
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.model.AdvancedModelLoader;
+import net.minecraftforge.client.model.IModelCustom;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import micdoodle8.mods.galacticraft.core.GalacticraftCore;
+import micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule;
+import micdoodle8.mods.galacticraft.planets.mars.MarsModule;
+
+@SideOnly(Side.CLIENT)
+public final class GalacticraftModels {
+
+    private GalacticraftModels() {}
+
+    private static IModelCustom aluminumWire;
+    private static IModelCustom aluminumWireHeavy;
+    private static IModelCustom buggy;
+    private static IModelCustom buggyWheelLeft;
+    private static IModelCustom buggyWheelRight;
+    private static IModelCustom cargoRocket;
+    private static IModelCustom chamber;
+    private static IModelCustom frequencyModule;
+    private static IModelCustom landingBalloon;
+    private static IModelCustom meteorChunk;
+    private static IModelCustom teleporter;
+    private static IModelCustom thruster;
+
+    public static IModelCustom getAluminumWire() {
+        if (aluminumWire == null) {
+            aluminumWire = loadModel(GalacticraftCore.ASSET_PREFIX, "models/aluminumWire.obj");
+        }
+        return aluminumWire;
+    }
+
+    public static IModelCustom getAluminumWireHeavy() {
+        if (aluminumWireHeavy == null) {
+            aluminumWireHeavy = loadModel(GalacticraftCore.ASSET_PREFIX, "models/aluminumWireHeavy.obj");
+        }
+        return aluminumWireHeavy;
+    }
+
+    public static IModelCustom getBuggy() {
+        if (buggy == null) {
+            buggy = loadModel(GalacticraftCore.ASSET_PREFIX, "models/buggy.obj");
+        }
+        return buggy;
+    }
+
+    public static IModelCustom getBuggyWheelLeft() {
+        if (buggyWheelLeft == null) {
+            buggyWheelLeft = loadModel(GalacticraftCore.ASSET_PREFIX, "models/buggyWheelLeft.obj");
+        }
+        return buggyWheelLeft;
+    }
+
+    public static IModelCustom getBuggyWheelRight() {
+        if (buggyWheelRight == null) {
+            buggyWheelRight = loadModel(GalacticraftCore.ASSET_PREFIX, "models/buggyWheelRight.obj");
+        }
+        return buggyWheelRight;
+    }
+
+    public static IModelCustom getCargoRocket() {
+        if (cargoRocket == null) {
+            cargoRocket = loadModel(MarsModule.ASSET_PREFIX, "models/cargoRocket.obj");
+        }
+        return cargoRocket;
+    }
+
+    public static IModelCustom getChamber() {
+        if (chamber == null) {
+            chamber = loadModel(MarsModule.ASSET_PREFIX, "models/chamber.obj");
+        }
+        return chamber;
+    }
+
+    public static IModelCustom getFrequencyModule() {
+        if (frequencyModule == null) {
+            frequencyModule = loadModel(GalacticraftCore.ASSET_PREFIX, "models/frequencyModule.obj");
+        }
+        return frequencyModule;
+    }
+
+    public static IModelCustom getLandingBalloon() {
+        if (landingBalloon == null) {
+            landingBalloon = loadModel(MarsModule.ASSET_PREFIX, "models/landingBalloon.obj");
+        }
+        return landingBalloon;
+    }
+
+    public static IModelCustom getMeteorChunk() {
+        if (meteorChunk == null) {
+            meteorChunk = loadModel(GalacticraftCore.ASSET_PREFIX, "models/meteorChunk.obj");
+        }
+        return meteorChunk;
+    }
+
+    public static IModelCustom getTeleporter() {
+        if (teleporter == null) {
+            teleporter = loadModel(AsteroidsModule.ASSET_PREFIX, "models/teleporter.obj");
+        }
+        return teleporter;
+    }
+
+    public static IModelCustom getThruster() {
+        if (thruster == null) {
+            thruster = loadModel(GalacticraftCore.ASSET_PREFIX, "models/thruster.obj");
+        }
+        return thruster;
+    }
+
+    private static IModelCustom loadModel(String prefix, String modelName) {
+        return AdvancedModelLoader.loadModel(new ResourceLocation(prefix, modelName));
+    }
+}

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/GalacticraftModels.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/GalacticraftModels.java
@@ -53,7 +53,6 @@ public final class GalacticraftModels {
     private static IModelCustom bubble;
     private static IModelCustom walkway;
 
-
     public static IModelCustom getAluminumWire() {
         if (aluminumWire == null) {
             aluminumWire = loadModel(GalacticraftCore.ASSET_PREFIX, "models/aluminumWire.obj");
@@ -138,176 +137,176 @@ public final class GalacticraftModels {
         return thruster;
     }
 
-    public static IModelCustom getDishSupport(){
-        if (support == null){
+    public static IModelCustom getDishSupport() {
+        if (support == null) {
             support = loadModel(GalacticraftCore.ASSET_PREFIX, "models/telesupport.obj");
         }
         return support;
     }
 
-    public static IModelCustom getDishFork(){
-        if (fork == null){
+    public static IModelCustom getDishFork() {
+        if (fork == null) {
             fork = loadModel(GalacticraftCore.ASSET_PREFIX, "models/telefork.obj");
         }
         return fork;
     }
 
-    public static IModelCustom getDish(){
-        if (dish == null){
+    public static IModelCustom getDish() {
+        if (dish == null) {
             dish = loadModel(GalacticraftCore.ASSET_PREFIX, "models/teledish.obj");
         }
         return dish;
     }
 
-    public static IModelCustom getPod(){
-        if (pod == null){
+    public static IModelCustom getPod() {
+        if (pod == null) {
             pod = loadModel(AsteroidsModule.ASSET_PREFIX, "models/pod.obj");
         }
         return pod;
     }
 
-    public static IModelCustom getRocketT3(){
-        if (rocketT3 == null){
+    public static IModelCustom getRocketT3() {
+        if (rocketT3 == null) {
             rocketT3 = loadModel(AsteroidsModule.ASSET_PREFIX, "models/tier3rocket.obj");
         }
         return rocketT3;
     }
 
-    public static IModelCustom getGrapple(){
-        if (grapple == null){
+    public static IModelCustom getGrapple() {
+        if (grapple == null) {
             grapple = loadModel(AsteroidsModule.ASSET_PREFIX, "models/grapple.obj");
         }
         return grapple;
     }
 
-    public static IModelCustom getLampBase(){
-        if (lampBase == null){
+    public static IModelCustom getLampBase() {
+        if (lampBase == null) {
             lampBase = loadModel(GalacticraftCore.ASSET_PREFIX, "models/arclampMetal.obj");
         }
         return lampBase;
     }
 
-    public static IModelCustom getLampMetal(){
-        if (lampMetal == null){
+    public static IModelCustom getLampMetal() {
+        if (lampMetal == null) {
             lampMetal = loadModel(GalacticraftCore.ASSET_PREFIX, "models/arclampLight.obj");
         }
         return lampMetal;
     }
 
-    public static IModelCustom getLampLight(){
-        if (lampLight == null){
+    public static IModelCustom getLampLight() {
+        if (lampLight == null) {
             lampLight = loadModel(GalacticraftCore.ASSET_PREFIX, "models/arclampBase.obj");
         }
         return lampLight;
     }
 
-    public static IModelCustom getWholeScreen(){
-        if (screenModel0 == null){
+    public static IModelCustom getWholeScreen() {
+        if (screenModel0 == null) {
             screenModel0 = loadModel(GalacticraftCore.ASSET_PREFIX, "models/screenWhole.obj");
         }
         return screenModel0;
     }
 
-    public static IModelCustom getScreenOQuarter(){
-        if (screenModel4 == null){
-            screenModel4 = loadModel(GalacticraftCore.ASSET_PREFIX,"models/screen0Quarters.obj");
+    public static IModelCustom getScreenOQuarter() {
+        if (screenModel4 == null) {
+            screenModel4 = loadModel(GalacticraftCore.ASSET_PREFIX, "models/screen0Quarters.obj");
         }
         return screenModel4;
     }
 
-    public static IModelCustom getScreen1Quarter(){
-        if (screenModel3 == null){
-            screenModel3 = loadModel(GalacticraftCore.ASSET_PREFIX,"models/screen1Quarters.obj");
+    public static IModelCustom getScreen1Quarter() {
+        if (screenModel3 == null) {
+            screenModel3 = loadModel(GalacticraftCore.ASSET_PREFIX, "models/screen1Quarters.obj");
         }
         return screenModel3;
     }
 
-    public static IModelCustom getScreen2Quarter(){
-        if (screenModel2 == null){
-            screenModel2 = loadModel(GalacticraftCore.ASSET_PREFIX,"models/screen2Quarters.obj");
+    public static IModelCustom getScreen2Quarter() {
+        if (screenModel2 == null) {
+            screenModel2 = loadModel(GalacticraftCore.ASSET_PREFIX, "models/screen2Quarters.obj");
         }
         return screenModel2;
     }
 
-    public static IModelCustom getScreen3Quarter(){
-        if (screenModel1 == null){
-            screenModel1 = loadModel(GalacticraftCore.ASSET_PREFIX,"models/screen3Quarters.obj");
+    public static IModelCustom getScreen3Quarter() {
+        if (screenModel1 == null) {
+            screenModel1 = loadModel(GalacticraftCore.ASSET_PREFIX, "models/screen3Quarters.obj");
         }
         return screenModel1;
     }
-    
-    public static IModelCustom getAstroMiner(){
-        if (astroMiner == null){
+
+    public static IModelCustom getAstroMiner() {
+        if (astroMiner == null) {
             astroMiner = loadModel(AsteroidsModule.ASSET_PREFIX, "models/astroMiner.obj");
         }
         return astroMiner;
     }
-    
-    public static IModelCustom getAstroMinerFrontLaser(){
-        if (astroMinerFrontLaser == null){
+
+    public static IModelCustom getAstroMinerFrontLaser() {
+        if (astroMinerFrontLaser == null) {
             astroMinerFrontLaser = loadModel(AsteroidsModule.ASSET_PREFIX, "models/astroMinerLaserFront.obj");
         }
         return astroMinerFrontLaser;
     }
 
-    public static IModelCustom getAstroMinerBottomLaser(){
-        if (astroMinerBottomLaser == null){
+    public static IModelCustom getAstroMinerBottomLaser() {
+        if (astroMinerBottomLaser == null) {
             astroMinerBottomLaser = loadModel(AsteroidsModule.ASSET_PREFIX, "models/astroMinerLaserBottom.obj");
         }
         return astroMinerBottomLaser;
     }
 
-    public static IModelCustom getAstroMinerCenterLaser(){
-        if (astroMinerCenterLaser == null){
+    public static IModelCustom getAstroMinerCenterLaser() {
+        if (astroMinerCenterLaser == null) {
             astroMinerCenterLaser = loadModel(AsteroidsModule.ASSET_PREFIX, "models/astroMinerLaserCenter.obj");
         }
         return astroMinerCenterLaser;
     }
 
-    public static IModelCustom getAstroMinerLeftLaserGuard(){
-        if (astroMinerLeftLaserGuard == null){
+    public static IModelCustom getAstroMinerLeftLaserGuard() {
+        if (astroMinerLeftLaserGuard == null) {
             astroMinerLeftLaserGuard = loadModel(AsteroidsModule.ASSET_PREFIX, "models/astroMinerLeftGuard.obj");
         }
         return astroMinerLeftLaserGuard;
     }
 
-    public static IModelCustom getAstroMinerRightLaserGuard(){
-        if (astroMinerRightLaserGuard == null){
+    public static IModelCustom getAstroMinerRightLaserGuard() {
+        if (astroMinerRightLaserGuard == null) {
             astroMinerRightLaserGuard = loadModel(AsteroidsModule.ASSET_PREFIX, "models/astroMinerRightGuard.obj");
         }
         return astroMinerRightLaserGuard;
     }
 
-    public static IModelCustom getBeamReceiver(){
-        if (beamReceiver == null){
+    public static IModelCustom getBeamReceiver() {
+        if (beamReceiver == null) {
             beamReceiver = loadModel(AsteroidsModule.ASSET_PREFIX, "models/receiver.obj");
         }
         return beamReceiver;
     }
 
-    public static IModelCustom getTelepad(){
-        if (telepad == null){
+    public static IModelCustom getTelepad() {
+        if (telepad == null) {
             telepad = loadModel(AsteroidsModule.ASSET_PREFIX, "models/minerbase.obj");
         }
         return telepad;
     }
 
-    public static IModelCustom getBeamReflector(){
-        if (beamReflector == null){
+    public static IModelCustom getBeamReflector() {
+        if (beamReflector == null) {
             beamReflector = loadModel(AsteroidsModule.ASSET_PREFIX, "models/reflector.obj");
         }
         return beamReflector;
     }
 
-    public static IModelCustom getBubble(){
-        if (bubble == null){
+    public static IModelCustom getBubble() {
+        if (bubble == null) {
             bubble = loadModel(GalacticraftCore.ASSET_PREFIX, "models/sphere.obj");
         }
         return bubble;
     }
 
-    public static IModelCustom getWalkway(){
-        if (walkway == null){
+    public static IModelCustom getWalkway() {
+        if (walkway == null) {
             walkway = loadModel(AsteroidsModule.ASSET_PREFIX, "models/walkway.obj");
         }
         return walkway;

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/GalacticraftModels.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/GalacticraftModels.java
@@ -27,6 +27,32 @@ public final class GalacticraftModels {
     private static IModelCustom meteorChunk;
     private static IModelCustom teleporter;
     private static IModelCustom thruster;
+    private static IModelCustom support;
+    private static IModelCustom fork;
+    private static IModelCustom dish;
+    private static IModelCustom pod;
+    private static IModelCustom rocketT3;
+    private static IModelCustom grapple;
+    private static IModelCustom lampMetal;
+    private static IModelCustom lampLight;
+    private static IModelCustom lampBase;
+    private static IModelCustom screenModel0;
+    private static IModelCustom screenModel1;
+    private static IModelCustom screenModel2;
+    private static IModelCustom screenModel3;
+    private static IModelCustom screenModel4;
+    private static IModelCustom astroMiner;
+    private static IModelCustom astroMinerFrontLaser;
+    private static IModelCustom astroMinerBottomLaser;
+    private static IModelCustom astroMinerCenterLaser;
+    private static IModelCustom astroMinerLeftLaserGuard;
+    private static IModelCustom astroMinerRightLaserGuard;
+    private static IModelCustom beamReceiver;
+    private static IModelCustom telepad;
+    private static IModelCustom beamReflector;
+    private static IModelCustom bubble;
+    private static IModelCustom walkway;
+
 
     public static IModelCustom getAluminumWire() {
         if (aluminumWire == null) {
@@ -110,6 +136,181 @@ public final class GalacticraftModels {
             thruster = loadModel(GalacticraftCore.ASSET_PREFIX, "models/thruster.obj");
         }
         return thruster;
+    }
+
+    public static IModelCustom getDishSupport(){
+        if (support == null){
+            support = loadModel(GalacticraftCore.ASSET_PREFIX, "models/telesupport.obj");
+        }
+        return support;
+    }
+
+    public static IModelCustom getDishFork(){
+        if (fork == null){
+            fork = loadModel(GalacticraftCore.ASSET_PREFIX, "models/telefork.obj");
+        }
+        return fork;
+    }
+
+    public static IModelCustom getDish(){
+        if (dish == null){
+            dish = loadModel(GalacticraftCore.ASSET_PREFIX, "models/teledish.obj");
+        }
+        return dish;
+    }
+
+    public static IModelCustom getPod(){
+        if (pod == null){
+            pod = loadModel(AsteroidsModule.ASSET_PREFIX, "models/pod.obj");
+        }
+        return pod;
+    }
+
+    public static IModelCustom getRocketT3(){
+        if (rocketT3 == null){
+            rocketT3 = loadModel(AsteroidsModule.ASSET_PREFIX, "models/tier3rocket.obj");
+        }
+        return rocketT3;
+    }
+
+    public static IModelCustom getGrapple(){
+        if (grapple == null){
+            grapple = loadModel(AsteroidsModule.ASSET_PREFIX, "models/grapple.obj");
+        }
+        return grapple;
+    }
+
+    public static IModelCustom getLampBase(){
+        if (lampBase == null){
+            lampBase = loadModel(GalacticraftCore.ASSET_PREFIX, "models/arclampMetal.obj");
+        }
+        return lampBase;
+    }
+
+    public static IModelCustom getLampMetal(){
+        if (lampMetal == null){
+            lampMetal = loadModel(GalacticraftCore.ASSET_PREFIX, "models/arclampLight.obj");
+        }
+        return lampMetal;
+    }
+
+    public static IModelCustom getLampLight(){
+        if (lampLight == null){
+            lampLight = loadModel(GalacticraftCore.ASSET_PREFIX, "models/arclampBase.obj");
+        }
+        return lampLight;
+    }
+
+    public static IModelCustom getWholeScreen(){
+        if (screenModel0 == null){
+            screenModel0 = loadModel(GalacticraftCore.ASSET_PREFIX, "models/screenWhole.obj");
+        }
+        return screenModel0;
+    }
+
+    public static IModelCustom getScreenOQuarter(){
+        if (screenModel4 == null){
+            screenModel4 = loadModel(GalacticraftCore.ASSET_PREFIX,"models/screen0Quarters.obj");
+        }
+        return screenModel4;
+    }
+
+    public static IModelCustom getScreen1Quarter(){
+        if (screenModel3 == null){
+            screenModel3 = loadModel(GalacticraftCore.ASSET_PREFIX,"models/screen1Quarters.obj");
+        }
+        return screenModel3;
+    }
+
+    public static IModelCustom getScreen2Quarter(){
+        if (screenModel2 == null){
+            screenModel2 = loadModel(GalacticraftCore.ASSET_PREFIX,"models/screen2Quarters.obj");
+        }
+        return screenModel2;
+    }
+
+    public static IModelCustom getScreen3Quarter(){
+        if (screenModel1 == null){
+            screenModel1 = loadModel(GalacticraftCore.ASSET_PREFIX,"models/screen3Quarters.obj");
+        }
+        return screenModel1;
+    }
+    
+    public static IModelCustom getAstroMiner(){
+        if (astroMiner == null){
+            astroMiner = loadModel(AsteroidsModule.ASSET_PREFIX, "models/astroMiner.obj");
+        }
+        return astroMiner;
+    }
+    
+    public static IModelCustom getAstroMinerFrontLaser(){
+        if (astroMinerFrontLaser == null){
+            astroMinerFrontLaser = loadModel(AsteroidsModule.ASSET_PREFIX, "models/astroMinerLaserFront.obj");
+        }
+        return astroMinerFrontLaser;
+    }
+
+    public static IModelCustom getAstroMinerBottomLaser(){
+        if (astroMinerBottomLaser == null){
+            astroMinerBottomLaser = loadModel(AsteroidsModule.ASSET_PREFIX, "models/astroMinerLaserBottom.obj");
+        }
+        return astroMinerBottomLaser;
+    }
+
+    public static IModelCustom getAstroMinerCenterLaser(){
+        if (astroMinerCenterLaser == null){
+            astroMinerCenterLaser = loadModel(AsteroidsModule.ASSET_PREFIX, "models/astroMinerLaserCenter.obj");
+        }
+        return astroMinerCenterLaser;
+    }
+
+    public static IModelCustom getAstroMinerLeftLaserGuard(){
+        if (astroMinerLeftLaserGuard == null){
+            astroMinerLeftLaserGuard = loadModel(AsteroidsModule.ASSET_PREFIX, "models/astroMinerLeftGuard.obj");
+        }
+        return astroMinerLeftLaserGuard;
+    }
+
+    public static IModelCustom getAstroMinerRightLaserGuard(){
+        if (astroMinerRightLaserGuard == null){
+            astroMinerRightLaserGuard = loadModel(AsteroidsModule.ASSET_PREFIX, "models/astroMinerRightGuard.obj");
+        }
+        return astroMinerRightLaserGuard;
+    }
+
+    public static IModelCustom getBeamReceiver(){
+        if (beamReceiver == null){
+            beamReceiver = loadModel(AsteroidsModule.ASSET_PREFIX, "models/receiver.obj");
+        }
+        return beamReceiver;
+    }
+
+    public static IModelCustom getTelepad(){
+        if (telepad == null){
+            telepad = loadModel(AsteroidsModule.ASSET_PREFIX, "models/minerbase.obj");
+        }
+        return telepad;
+    }
+
+    public static IModelCustom getBeamReflector(){
+        if (beamReflector == null){
+            beamReflector = loadModel(AsteroidsModule.ASSET_PREFIX, "models/reflector.obj");
+        }
+        return beamReflector;
+    }
+
+    public static IModelCustom getBubble(){
+        if (bubble == null){
+            bubble = loadModel(GalacticraftCore.ASSET_PREFIX, "models/sphere.obj");
+        }
+        return bubble;
+    }
+
+    public static IModelCustom getWalkway(){
+        if (walkway == null){
+            walkway = loadModel(AsteroidsModule.ASSET_PREFIX, "models/walkway.obj");
+        }
+        return walkway;
     }
 
     private static IModelCustom loadModel(String prefix, String modelName) {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/model/ModelPlayerBaseGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/model/ModelPlayerBaseGC.java
@@ -17,7 +17,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.client.model.IModelCustom;
 import net.smart.render.playerapi.SmartRender;
 
 import org.lwjgl.opengl.GL11;
@@ -51,7 +50,6 @@ public class ModelPlayerBaseGC extends ModelPlayerBase {
 
     private boolean usingParachute;
 
-    protected static IModelCustom frequencyModule;
     public static AbstractClientPlayer playerRendering;
     protected static PlayerGearData currentGearData;
 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/model/ModelPlayerGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/model/ModelPlayerGC.java
@@ -15,7 +15,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.client.model.AdvancedModelLoader;
 import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
@@ -25,6 +24,7 @@ import micdoodle8.mods.galacticraft.api.item.IHoldableItem;
 import micdoodle8.mods.galacticraft.api.prefab.entity.EntityTieredRocket;
 import micdoodle8.mods.galacticraft.api.world.IGalacticraftWorldProvider;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.core.network.PacketSimple;
 import micdoodle8.mods.galacticraft.core.proxy.ClientProxyCore;
 import micdoodle8.mods.galacticraft.core.wrappers.PlayerGearData;
@@ -218,8 +218,7 @@ public class ModelPlayerGC extends ModelBiped {
         this.grayOxygenTanks[1].setRotationPoint(-2F, 2F, 3.8F);
         this.grayOxygenTanks[1].mirror = true;
 
-        this.frequencyModule = AdvancedModelLoader
-                .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/frequencyModule.obj"));
+        this.frequencyModule = GalacticraftModels.getFrequencyModule();
     }
 
     @Override

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/model/ModelRotationRendererGC.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/model/ModelRotationRendererGC.java
@@ -2,14 +2,13 @@ package micdoodle8.mods.galacticraft.core.client.model;
 
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
-import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.client.model.AdvancedModelLoader;
+import net.minecraftforge.client.model.IModelCustom;
 import net.smart.render.ModelRotationRenderer;
 
 import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.client.FMLClientHandler;
-import micdoodle8.mods.galacticraft.core.GalacticraftCore;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 
 /**
  * If Smart Moving is installed, this is used by ModelPlayerBaseGC as the ModelRenderer - see
@@ -24,13 +23,13 @@ import micdoodle8.mods.galacticraft.core.GalacticraftCore;
  */
 public class ModelRotationRendererGC extends ModelRotationRenderer {
 
+    private final IModelCustom freqModuleModel;
     private final int type;
 
     public ModelRotationRendererGC(ModelBase modelBase, int i, int j, ModelRenderer baseRenderer, int type) {
         super(modelBase, i, j, (ModelRotationRenderer) baseRenderer);
         this.type = type;
-        ModelPlayerBaseGC.frequencyModule = AdvancedModelLoader
-                .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/frequencyModule.obj"));
+        this.freqModuleModel = GalacticraftModels.getFrequencyModule();
     }
 
     @Override
@@ -111,7 +110,7 @@ public class ModelRotationRendererGC extends ModelRotationRenderer {
                 GL11.glRotatef(180, 1, 0, 0);
                 GL11.glScalef(0.3F, 0.3F, 0.3F);
                 GL11.glTranslatef(-1.1F, 1.2F, 0);
-                ModelPlayerBaseGC.frequencyModule.renderPart("Main");
+                this.freqModuleModel.renderPart("Main");
                 GL11.glTranslatef(0, 1.2F, 0);
                 GL11.glRotatef(
                         (float) (Math.sin(ModelPlayerBaseGC.playerRendering.ticksExisted * 0.05) * 50.0F),
@@ -124,7 +123,7 @@ public class ModelRotationRendererGC extends ModelRotationRenderer {
                         1,
                         0);
                 GL11.glTranslatef(0, -1.2F, 0);
-                ModelPlayerBaseGC.frequencyModule.renderPart("Radar");
+                this.freqModuleModel.renderPart("Radar");
                 GL11.glPopMatrix();
             }
 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/entities/RenderBuggy.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/entities/RenderBuggy.java
@@ -3,7 +3,6 @@ package micdoodle8.mods.galacticraft.core.client.render.entities;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.client.model.AdvancedModelLoader;
 import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
@@ -11,6 +10,7 @@ import org.lwjgl.opengl.GL11;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.core.entities.EntityBuggy;
 
 @SideOnly(Side.CLIENT)
@@ -26,12 +26,9 @@ public class RenderBuggy extends Render {
             GalacticraftCore.ASSET_PREFIX,
             "textures/model/buggyStorage.png");
 
-    private final IModelCustom modelBuggy = AdvancedModelLoader
-            .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/buggy.obj"));
-    private final IModelCustom modelBuggyWheelRight = AdvancedModelLoader
-            .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/buggyWheelRight.obj"));
-    private final IModelCustom modelBuggyWheelLeft = AdvancedModelLoader
-            .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/buggyWheelLeft.obj"));
+    private final IModelCustom modelBuggy = GalacticraftModels.getBuggy();
+    private final IModelCustom modelBuggyWheelLeft = GalacticraftModels.getBuggyWheelLeft();
+    private final IModelCustom modelBuggyWheelRight = GalacticraftModels.getBuggyWheelRight();
 
     public RenderBuggy() {
         this.shadowSize = 2.0F;

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/entities/RenderMeteorChunk.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/entities/RenderMeteorChunk.java
@@ -3,12 +3,12 @@ package micdoodle8.mods.galacticraft.core.client.render.entities;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.client.model.AdvancedModelLoader;
 import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
 
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.core.entities.EntityMeteorChunk;
 
 public class RenderMeteorChunk extends Render {
@@ -20,8 +20,7 @@ public class RenderMeteorChunk extends Render {
             GalacticraftCore.ASSET_PREFIX,
             "textures/model/meteorChunkHot.png");
 
-    private final IModelCustom meteorChunkModel = AdvancedModelLoader
-            .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/meteorChunk.obj"));
+    private final IModelCustom meteorChunkModel = GalacticraftModels.getMeteorChunk();
 
     public RenderMeteorChunk() {
         this.shadowSize = 0.1F;

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/item/ItemRendererArclamp.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/item/ItemRendererArclamp.java
@@ -11,6 +11,9 @@ import org.lwjgl.opengl.GL11;
 import cpw.mods.fml.client.FMLClientHandler;
 import micdoodle8.mods.galacticraft.core.client.render.tile.TileEntityArclampRenderer;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getLampLight;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getLampMetal;
+
 public class ItemRendererArclamp implements IItemRenderer {
 
     private void renderArclamp(ItemRenderType type) {
@@ -37,7 +40,7 @@ public class ItemRendererArclamp implements IItemRenderer {
         GL11.glScalef(0.07F, 0.07F, 0.07F);
         GL11.glRotatef(90, 0, 0, -1);
         FMLClientHandler.instance().getClient().getTextureManager().bindTexture(TileEntityArclampRenderer.lampTexture);
-        TileEntityArclampRenderer.lampMetal.renderAll();
+        getLampMetal().renderAll();
 
         OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240F, 240F);
         FMLClientHandler.instance().getClient().getTextureManager().bindTexture(TileEntityArclampRenderer.lightTexture);
@@ -45,7 +48,7 @@ public class ItemRendererArclamp implements IItemRenderer {
         tessellator.startDrawing(GL11.GL_QUADS);
         tessellator.setColorRGBA(255, 255, 255, 255);
         GL11.glDisable(GL11.GL_LIGHTING);
-        ((WavefrontObject) TileEntityArclampRenderer.lampLight).tessellateAll(tessellator);
+        ((WavefrontObject) getLampLight()).tessellateAll(tessellator);
         tessellator.draw();
 
         GL11.glPopMatrix();

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/item/ItemRendererArclamp.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/item/ItemRendererArclamp.java
@@ -1,20 +1,22 @@
 package micdoodle8.mods.galacticraft.core.client.render.item;
 
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getLampLight;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getLampMetal;
-
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.IItemRenderer;
+import net.minecraftforge.client.model.IModelCustom;
 import net.minecraftforge.client.model.obj.WavefrontObject;
 
 import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.client.FMLClientHandler;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.core.client.render.tile.TileEntityArclampRenderer;
 
 public class ItemRendererArclamp implements IItemRenderer {
+
+    private final IModelCustom lampMetal = GalacticraftModels.getLampMetal();
+    private final WavefrontObject lampLight = ((WavefrontObject) GalacticraftModels.getLampLight());
 
     private void renderArclamp(ItemRenderType type) {
         GL11.glPushMatrix();
@@ -40,7 +42,7 @@ public class ItemRendererArclamp implements IItemRenderer {
         GL11.glScalef(0.07F, 0.07F, 0.07F);
         GL11.glRotatef(90, 0, 0, -1);
         FMLClientHandler.instance().getClient().getTextureManager().bindTexture(TileEntityArclampRenderer.lampTexture);
-        getLampMetal().renderAll();
+        lampMetal.renderAll();
 
         OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240F, 240F);
         FMLClientHandler.instance().getClient().getTextureManager().bindTexture(TileEntityArclampRenderer.lightTexture);
@@ -48,7 +50,7 @@ public class ItemRendererArclamp implements IItemRenderer {
         tessellator.startDrawing(GL11.GL_QUADS);
         tessellator.setColorRGBA(255, 255, 255, 255);
         GL11.glDisable(GL11.GL_LIGHTING);
-        ((WavefrontObject) getLampLight()).tessellateAll(tessellator);
+        lampLight.tessellateAll(tessellator);
         tessellator.draw();
 
         GL11.glPopMatrix();

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/item/ItemRendererArclamp.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/item/ItemRendererArclamp.java
@@ -1,5 +1,8 @@
 package micdoodle8.mods.galacticraft.core.client.render.item;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getLampLight;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getLampMetal;
+
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.item.ItemStack;
@@ -10,9 +13,6 @@ import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.client.FMLClientHandler;
 import micdoodle8.mods.galacticraft.core.client.render.tile.TileEntityArclampRenderer;
-
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getLampLight;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getLampMetal;
 
 public class ItemRendererArclamp implements IItemRenderer {
 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/item/ItemRendererBuggy.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/item/ItemRendererBuggy.java
@@ -3,14 +3,13 @@ package micdoodle8.mods.galacticraft.core.client.render.item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.IItemRenderer;
-import net.minecraftforge.client.model.AdvancedModelLoader;
 import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.client.FMLClientHandler;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
-import micdoodle8.mods.galacticraft.core.entities.EntityBuggy;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 
 public class ItemRendererBuggy implements IItemRenderer {
 
@@ -24,12 +23,9 @@ public class ItemRendererBuggy implements IItemRenderer {
             GalacticraftCore.ASSET_PREFIX,
             "textures/model/buggyStorage.png");
 
-    private final IModelCustom modelBuggy = AdvancedModelLoader
-            .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/buggy.obj"));
-    private final IModelCustom modelBuggyWheelRight = AdvancedModelLoader
-            .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/buggyWheelRight.obj"));
-    private final IModelCustom modelBuggyWheelLeft = AdvancedModelLoader
-            .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/buggyWheelLeft.obj"));
+    private final IModelCustom modelBuggy = GalacticraftModels.getBuggy();
+    private final IModelCustom modelBuggyWheelLeft = GalacticraftModels.getBuggyWheelLeft();
+    private final IModelCustom modelBuggyWheelRight = GalacticraftModels.getBuggyWheelRight();
 
     private void renderPipeItem(ItemRenderType type, ItemStack item) {
         GL11.glPushMatrix();

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/item/ItemRendererBuggy.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/item/ItemRendererBuggy.java
@@ -24,8 +24,6 @@ public class ItemRendererBuggy implements IItemRenderer {
             GalacticraftCore.ASSET_PREFIX,
             "textures/model/buggyStorage.png");
 
-    EntityBuggy spaceship = new EntityBuggy(FMLClientHandler.instance().getClient().theWorld);
-
     private final IModelCustom modelBuggy = AdvancedModelLoader
             .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/buggy.obj"));
     private final IModelCustom modelBuggyWheelRight = AdvancedModelLoader
@@ -35,7 +33,7 @@ public class ItemRendererBuggy implements IItemRenderer {
 
     private void renderPipeItem(ItemRenderType type, ItemStack item) {
         GL11.glPushMatrix();
-        long var10 = this.spaceship.getEntityId() * 493286711L;
+        long var10 = 69 * 493286711L;
         var10 = var10 * var10 * 4392167121L + var10 * 98761L;
         final float var12 = (((var10 >> 16 & 7L) + 0.5F) / 8.0F - 0.5F) * 0.004F;
         final float var13 = (((var10 >> 20 & 7L) + 0.5F) / 8.0F - 0.5F) * 0.004F;

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/item/ItemRendererMeteorChunk.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/item/ItemRendererMeteorChunk.java
@@ -3,13 +3,13 @@ package micdoodle8.mods.galacticraft.core.client.render.item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.IItemRenderer;
-import net.minecraftforge.client.model.AdvancedModelLoader;
 import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.client.FMLClientHandler;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 
 public class ItemRendererMeteorChunk implements IItemRenderer {
 
@@ -20,8 +20,7 @@ public class ItemRendererMeteorChunk implements IItemRenderer {
             GalacticraftCore.ASSET_PREFIX,
             "textures/model/meteorChunkHot.png");
 
-    private final IModelCustom meteorChunkModel = AdvancedModelLoader
-            .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/meteorChunk.obj"));
+    private final IModelCustom meteorChunkModel = GalacticraftModels.getMeteorChunk();
 
     private void renderMeteorChunk(ItemRenderType type, ItemStack item) {
         GL11.glPushMatrix();

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/item/ItemRendererScreen.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/item/ItemRendererScreen.java
@@ -1,5 +1,7 @@
 package micdoodle8.mods.galacticraft.core.client.render.item;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getWholeScreen;
+
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.IItemRenderer;
 
@@ -7,8 +9,6 @@ import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.client.FMLClientHandler;
 import micdoodle8.mods.galacticraft.core.client.render.tile.TileEntityScreenRenderer;
-
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getWholeScreen;
 
 public class ItemRendererScreen implements IItemRenderer {
 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/item/ItemRendererScreen.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/item/ItemRendererScreen.java
@@ -8,6 +8,8 @@ import org.lwjgl.opengl.GL11;
 import cpw.mods.fml.client.FMLClientHandler;
 import micdoodle8.mods.galacticraft.core.client.render.tile.TileEntityScreenRenderer;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getWholeScreen;
+
 public class ItemRendererScreen implements IItemRenderer {
 
     private void renderScreen(ItemRenderType type) {
@@ -38,7 +40,7 @@ public class ItemRendererScreen implements IItemRenderer {
         }
 
         GL11.glRotatef(90, 0, 0, -1);
-        TileEntityScreenRenderer.screenModel0.renderAll();
+        getWholeScreen().renderAll();
 
         GL11.glPopMatrix();
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/item/ItemRendererScreen.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/item/ItemRendererScreen.java
@@ -1,16 +1,18 @@
 package micdoodle8.mods.galacticraft.core.client.render.item;
 
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getWholeScreen;
-
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.IItemRenderer;
+import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.client.FMLClientHandler;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.core.client.render.tile.TileEntityScreenRenderer;
 
 public class ItemRendererScreen implements IItemRenderer {
+
+    private final IModelCustom wholeScreen = GalacticraftModels.getWholeScreen();
 
     private void renderScreen(ItemRenderType type) {
         GL11.glPushMatrix();
@@ -40,7 +42,7 @@ public class ItemRendererScreen implements IItemRenderer {
         }
 
         GL11.glRotatef(90, 0, 0, -1);
-        getWholeScreen().renderAll();
+        wholeScreen.renderAll();
 
         GL11.glPopMatrix();
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/item/ItemRendererThruster.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/item/ItemRendererThruster.java
@@ -2,13 +2,17 @@ package micdoodle8.mods.galacticraft.core.client.render.item;
 
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.IItemRenderer;
+import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.client.FMLClientHandler;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.core.client.render.tile.TileEntityThrusterRenderer;
 
 public class ItemRendererThruster implements IItemRenderer {
+
+    private final IModelCustom thrusterModel = GalacticraftModels.getThruster();
 
     private void renderThruster(ItemRenderType type) {
         GL11.glPushMatrix();
@@ -35,7 +39,7 @@ public class ItemRendererThruster implements IItemRenderer {
         }
 
         GL11.glRotatef(180, 1, 0, 0);
-        TileEntityThrusterRenderer.thrusterModel.renderAll();
+        this.thrusterModel.renderAll();
 
         GL11.glPopMatrix();
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityAluminumWireRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityAluminumWireRenderer.java
@@ -3,7 +3,6 @@ package micdoodle8.mods.galacticraft.core.client.render.tile;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.client.model.AdvancedModelLoader;
 import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
@@ -12,6 +11,7 @@ import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.core.energy.EnergyUtil;
 import micdoodle8.mods.galacticraft.core.tile.TileEntityAluminumWire;
 
@@ -22,14 +22,12 @@ public class TileEntityAluminumWireRenderer extends TileEntitySpecialRenderer {
             GalacticraftCore.ASSET_PREFIX,
             "textures/model/aluminumWire.png");
 
-    public final IModelCustom model;
-    public final IModelCustom model2;
+    private final IModelCustom model;
+    private final IModelCustom model2;
 
     public TileEntityAluminumWireRenderer() {
-        this.model = AdvancedModelLoader
-                .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/aluminumWire.obj"));
-        this.model2 = AdvancedModelLoader
-                .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/aluminumWireHeavy.obj"));
+        this.model = GalacticraftModels.getAluminumWire();
+        this.model2 = GalacticraftModels.getAluminumWireHeavy();
     }
 
     public void renderModelAt(TileEntityAluminumWire tileEntity, double d, double d1, double d2, float f) {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityArclampRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityArclampRenderer.java
@@ -1,15 +1,12 @@
 package micdoodle8.mods.galacticraft.core.client.render.tile;
 
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getLampBase;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getLampLight;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getLampMetal;
-
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.model.IModelCustom;
 import net.minecraftforge.client.model.obj.WavefrontObject;
 
 import org.lwjgl.opengl.GL11;
@@ -18,6 +15,7 @@ import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.core.tile.TileEntityArclamp;
 
 @SideOnly(Side.CLIENT)
@@ -30,6 +28,9 @@ public class TileEntityArclampRenderer extends TileEntitySpecialRenderer {
             GalacticraftCore.ASSET_PREFIX,
             "textures/misc/light.png");
     private final TextureManager renderEngine = FMLClientHandler.instance().getClient().renderEngine;
+    private final IModelCustom lampBase = GalacticraftModels.getLampBase();
+    private final WavefrontObject lampLight = ((WavefrontObject) GalacticraftModels.getLampLight());
+    private final IModelCustom lampMetal = GalacticraftModels.getLampMetal();
 
     public void renderModelAt(TileEntityArclamp tileEntity, double d, double d1, double d2, float f) {
         final int side = tileEntity.getBlockMetadata();
@@ -87,10 +88,10 @@ public class TileEntityArclampRenderer extends TileEntitySpecialRenderer {
 
         this.renderEngine.bindTexture(TileEntityArclampRenderer.lampTexture);
         GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-        getLampBase().renderAll();
+        lampBase.renderAll();
         GL11.glRotatef(45F, -1F, 0, 0);
         GL11.glScalef(0.048F, 0.048F, 0.048F);
-        getLampMetal().renderAll();
+        lampMetal.renderAll();
 
         final int whiteLevel = tileEntity.getEnabled() ? 255 : 26;
 
@@ -104,7 +105,7 @@ public class TileEntityArclampRenderer extends TileEntitySpecialRenderer {
         final Tessellator tessellator = Tessellator.instance;
         tessellator.startDrawing(GL11.GL_QUADS);
         tessellator.setColorRGBA(whiteLevel, whiteLevel, whiteLevel, 255);
-        ((WavefrontObject) getLampLight()).tessellateAll(tessellator);
+        lampLight.tessellateAll(tessellator);
         tessellator.draw();
 
         // Restore the lighting state

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityArclampRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityArclampRenderer.java
@@ -1,13 +1,15 @@
 package micdoodle8.mods.galacticraft.core.client.render.tile;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getLampBase;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getLampLight;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getLampMetal;
+
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.client.model.AdvancedModelLoader;
-import net.minecraftforge.client.model.IModelCustom;
 import net.minecraftforge.client.model.obj.WavefrontObject;
 
 import org.lwjgl.opengl.GL11;
@@ -17,10 +19,6 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.tile.TileEntityArclamp;
-
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getLampBase;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getLampLight;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getLampMetal;
 
 @SideOnly(Side.CLIENT)
 public class TileEntityArclampRenderer extends TileEntitySpecialRenderer {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityArclampRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityArclampRenderer.java
@@ -18,6 +18,10 @@ import cpw.mods.fml.relauncher.SideOnly;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.tile.TileEntityArclamp;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getLampBase;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getLampLight;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getLampMetal;
+
 @SideOnly(Side.CLIENT)
 public class TileEntityArclampRenderer extends TileEntitySpecialRenderer {
 
@@ -27,25 +31,11 @@ public class TileEntityArclampRenderer extends TileEntitySpecialRenderer {
     public static final ResourceLocation lightTexture = new ResourceLocation(
             GalacticraftCore.ASSET_PREFIX,
             "textures/misc/light.png");
-    public static final IModelCustom lampMetal = AdvancedModelLoader
-            .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/arclampMetal.obj"));
-    public static final IModelCustom lampLight = AdvancedModelLoader
-            .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/arclampLight.obj"));
-    public static final IModelCustom lampBase = AdvancedModelLoader
-            .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/arclampBase.obj"));
     private final TextureManager renderEngine = FMLClientHandler.instance().getClient().renderEngine;
 
     public void renderModelAt(TileEntityArclamp tileEntity, double d, double d1, double d2, float f) {
         final int side = tileEntity.getBlockMetadata();
         int metaFacing = tileEntity.facing;
-
-        // int facing;
-        /*
-         * switch (side) { case 0: case 1: facing = metaFacing + 2; break; case 2: facing = metaFacing; if (metaFacing >
-         * 1) facing= 7 - metaFacing; break; case 3: facing = metaFacing; if (metaFacing > 1) facing+=2; break; case 4:
-         * facing = metaFacing; break; case 5: facing = metaFacing; if (metaFacing > 1) facing= 5 - metaFacing; break;
-         * default: return; }
-         */
 
         GL11.glPushMatrix();
         GL11.glTranslatef((float) d + 0.5F, (float) d1 + 0.5F, (float) d2 + 0.5F);
@@ -99,10 +89,10 @@ public class TileEntityArclampRenderer extends TileEntitySpecialRenderer {
 
         this.renderEngine.bindTexture(TileEntityArclampRenderer.lampTexture);
         GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-        TileEntityArclampRenderer.lampBase.renderAll();
+        getLampBase().renderAll();
         GL11.glRotatef(45F, -1F, 0, 0);
         GL11.glScalef(0.048F, 0.048F, 0.048F);
-        TileEntityArclampRenderer.lampMetal.renderAll();
+        getLampMetal().renderAll();
 
         final int whiteLevel = tileEntity.getEnabled() ? 255 : 26;
 
@@ -116,7 +106,7 @@ public class TileEntityArclampRenderer extends TileEntitySpecialRenderer {
         final Tessellator tessellator = Tessellator.instance;
         tessellator.startDrawing(GL11.GL_QUADS);
         tessellator.setColorRGBA(whiteLevel, whiteLevel, whiteLevel, 255);
-        ((WavefrontObject) TileEntityArclampRenderer.lampLight).tessellateAll(tessellator);
+        ((WavefrontObject) getLampLight()).tessellateAll(tessellator);
         tessellator.draw();
 
         // Restore the lighting state

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityBubbleProviderRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityBubbleProviderRenderer.java
@@ -1,19 +1,17 @@
 package micdoodle8.mods.galacticraft.core.client.render.tile;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getBubble;
+
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.client.model.AdvancedModelLoader;
-import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.entities.IBubbleProvider;
-
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getBubble;
 
 public class TileEntityBubbleProviderRenderer extends TileEntitySpecialRenderer {
 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityBubbleProviderRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityBubbleProviderRenderer.java
@@ -13,21 +13,19 @@ import org.lwjgl.opengl.GL12;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.entities.IBubbleProvider;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getBubble;
+
 public class TileEntityBubbleProviderRenderer extends TileEntitySpecialRenderer {
 
     private static final ResourceLocation oxygenBubbleTexture = new ResourceLocation(
             GalacticraftCore.ASSET_PREFIX,
             "textures/model/bubble.png");
 
-    private static IModelCustom sphere;
-
     private final float colorRed;
     private final float colorGreen;
     private final float colorBlue;
 
     public TileEntityBubbleProviderRenderer(float colorRed, float colorGreen, float colorBlue) {
-        sphere = AdvancedModelLoader
-                .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/sphere.obj"));
         this.colorRed = colorRed;
         this.colorGreen = colorGreen;
         this.colorBlue = colorBlue;
@@ -62,7 +60,7 @@ public class TileEntityBubbleProviderRenderer extends TileEntitySpecialRenderer 
         OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240F, 240F);
         GL11.glScalef(provider.getBubbleSize(), provider.getBubbleSize(), provider.getBubbleSize());
 
-        sphere.renderAll();
+        getBubble().renderAll();
 
         GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
         GL11.glMatrixMode(GL11.GL_TEXTURE);

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityBubbleProviderRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityBubbleProviderRenderer.java
@@ -1,16 +1,16 @@
 package micdoodle8.mods.galacticraft.core.client.render.tile;
 
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getBubble;
-
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.core.entities.IBubbleProvider;
 
 public class TileEntityBubbleProviderRenderer extends TileEntitySpecialRenderer {
@@ -22,6 +22,7 @@ public class TileEntityBubbleProviderRenderer extends TileEntitySpecialRenderer 
     private final float colorRed;
     private final float colorGreen;
     private final float colorBlue;
+    private final IModelCustom bubble = GalacticraftModels.getBubble();
 
     public TileEntityBubbleProviderRenderer(float colorRed, float colorGreen, float colorBlue) {
         this.colorRed = colorRed;
@@ -58,7 +59,7 @@ public class TileEntityBubbleProviderRenderer extends TileEntitySpecialRenderer 
         OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240F, 240F);
         GL11.glScalef(provider.getBubbleSize(), provider.getBubbleSize(), provider.getBubbleSize());
 
-        getBubble().renderAll();
+        bubble.renderAll();
 
         GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
         GL11.glMatrixMode(GL11.GL_TEXTURE);

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityDishRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityDishRenderer.java
@@ -1,20 +1,18 @@
 package micdoodle8.mods.galacticraft.core.client.render.tile;
 
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getDish;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getDishFork;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getDishSupport;
-
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
 import cpw.mods.fml.client.FMLClientHandler;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.core.tile.TileEntityDish;
 
 public class TileEntityDishRenderer extends TileEntitySpecialRenderer {
@@ -29,6 +27,9 @@ public class TileEntityDishRenderer extends TileEntitySpecialRenderer {
             GalacticraftCore.ASSET_PREFIX,
             "textures/model/teledish.png");
     private final TextureManager renderEngine = FMLClientHandler.instance().getClient().renderEngine;
+    private final IModelCustom dishSupport = GalacticraftModels.getDishSupport();
+    private final IModelCustom dishFork = GalacticraftModels.getDishFork();
+    private final IModelCustom dish = GalacticraftModels.getDish();
 
     @Override
     public void renderTileEntityAt(TileEntity var1, double par2, double par4, double par6, float partialTickTime) {
@@ -43,17 +44,17 @@ public class TileEntityDishRenderer extends TileEntitySpecialRenderer {
         GL11.glScalef(2.0F, 2.0F, 2.0F);
 
         this.renderEngine.bindTexture(textureSupport);
-        getDishSupport().renderAll();
+        dishSupport.renderAll();
         GL11.glRotatef(time / 4, 0, -1, 0);
         this.renderEngine.bindTexture(textureFork);
-        getDishFork().renderAll();
+        dishFork.renderAll();
 
         GL11.glTranslatef(0.0F, 2.3F, 0.0F);
         GL11.glRotatef((MathHelper.sin(time / 144) + 1.0F) * 22.5F, 1.0F, 0.0F, 0.0F);
         GL11.glTranslatef(0.0F, -2.3F, 0.0F);
 
         this.renderEngine.bindTexture(textureDish);
-        getDish().renderAll();
+        this.dish.renderAll();
 
         GL11.glDisable(GL12.GL_RESCALE_NORMAL);
         GL11.glPopMatrix();

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityDishRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityDishRenderer.java
@@ -15,6 +15,10 @@ import cpw.mods.fml.client.FMLClientHandler;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.tile.TileEntityDish;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getDish;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getDishFork;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getDishSupport;
+
 public class TileEntityDishRenderer extends TileEntitySpecialRenderer {
 
     private static final ResourceLocation textureSupport = new ResourceLocation(
@@ -26,12 +30,6 @@ public class TileEntityDishRenderer extends TileEntitySpecialRenderer {
     private static final ResourceLocation textureDish = new ResourceLocation(
             GalacticraftCore.ASSET_PREFIX,
             "textures/model/teledish.png");
-    private static final IModelCustom modelSupport = AdvancedModelLoader
-            .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/telesupport.obj"));
-    private static final IModelCustom modelFork = AdvancedModelLoader
-            .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/telefork.obj"));
-    private static final IModelCustom modelDish = AdvancedModelLoader
-            .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/teledish.obj"));
     private final TextureManager renderEngine = FMLClientHandler.instance().getClient().renderEngine;
 
     @Override
@@ -47,21 +45,17 @@ public class TileEntityDishRenderer extends TileEntitySpecialRenderer {
         GL11.glScalef(2.0F, 2.0F, 2.0F);
 
         this.renderEngine.bindTexture(textureSupport);
-        modelSupport.renderAll();
+        getDishSupport().renderAll();
         GL11.glRotatef(time / 4, 0, -1, 0);
         this.renderEngine.bindTexture(textureFork);
-        modelFork.renderAll();
-
-        // float celestialAngle = (dish.getWorldObj().getCelestialAngle(1.0F) -
-        // 0.784690560F) * 360.0F;
-        // float celestialAngle2 = dish.getWorldObj().getCelestialAngle(1.0F) * 360.0F;
+        getDishFork().renderAll();
 
         GL11.glTranslatef(0.0F, 2.3F, 0.0F);
         GL11.glRotatef((MathHelper.sin(time / 144) + 1.0F) * 22.5F, 1.0F, 0.0F, 0.0F);
         GL11.glTranslatef(0.0F, -2.3F, 0.0F);
 
         this.renderEngine.bindTexture(textureDish);
-        modelDish.renderAll();
+        getDish().renderAll();
 
         GL11.glDisable(GL12.GL_RESCALE_NORMAL);
         GL11.glPopMatrix();

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityDishRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityDishRenderer.java
@@ -1,12 +1,14 @@
 package micdoodle8.mods.galacticraft.core.client.render.tile;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getDish;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getDishFork;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getDishSupport;
+
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.client.model.AdvancedModelLoader;
-import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
@@ -14,10 +16,6 @@ import org.lwjgl.opengl.GL12;
 import cpw.mods.fml.client.FMLClientHandler;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.tile.TileEntityDish;
-
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getDish;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getDishFork;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getDishSupport;
 
 public class TileEntityDishRenderer extends TileEntitySpecialRenderer {
 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityScreenRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityScreenRenderer.java
@@ -1,15 +1,10 @@
 package micdoodle8.mods.galacticraft.core.client.render.tile;
 
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getScreen1Quarter;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getScreen2Quarter;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getScreen3Quarter;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getScreenOQuarter;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getWholeScreen;
-
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
 
@@ -17,6 +12,7 @@ import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.core.tile.TileEntityScreen;
 
 @SideOnly(Side.CLIENT)
@@ -27,8 +23,11 @@ public class TileEntityScreenRenderer extends TileEntitySpecialRenderer {
             "textures/blocks/screenSide.png");
 
     private final TextureManager renderEngine = FMLClientHandler.instance().getClient().renderEngine;
-
-    private final float yPlane = 0.91F;
+    private final IModelCustom wholeScreen = GalacticraftModels.getWholeScreen();
+    private final IModelCustom screen3Quarter = GalacticraftModels.getScreen3Quarter();
+    private final IModelCustom screen2Quarter = GalacticraftModels.getScreen2Quarter();
+    private final IModelCustom screen1Quarter = GalacticraftModels.getScreen1Quarter();
+    private final IModelCustom screenOQuarter = GalacticraftModels.getScreenOQuarter();
 
     public void renderModelAt(TileEntityScreen tileEntity, double d, double d1, double d2, float f) {
         GL11.glPushMatrix();
@@ -90,7 +89,7 @@ public class TileEntityScreenRenderer extends TileEntitySpecialRenderer {
             case 0:
                 GL11.glTranslatef(-0.001F, -0.001F, -0.001F);
                 GL11.glScalef(1.002F, 1.002F, 1.002F);
-                getWholeScreen().renderAll();
+                wholeScreen.renderAll();
                 break;
             case 1:
                 if (tileEntity.connectedUp) {
@@ -105,7 +104,7 @@ public class TileEntityScreenRenderer extends TileEntitySpecialRenderer {
                 }
                 GL11.glTranslatef(-0.001F, -0.001F, -0.001F);
                 GL11.glScalef(1.002F, 1.002F, 1.002F);
-                getScreen3Quarter().renderAll();
+                screen3Quarter.renderAll();
                 break;
             case 2:
                 if (!tileEntity.connectedRight && !tileEntity.connectedDown) {
@@ -120,7 +119,7 @@ public class TileEntityScreenRenderer extends TileEntitySpecialRenderer {
                 }
                 GL11.glTranslatef(-0.001F, -0.001F, -0.001F);
                 GL11.glScalef(1.002F, 1.002F, 1.002F);
-                getScreen2Quarter().renderAll();
+                screen2Quarter.renderAll();
                 break;
             case 3:
                 if (!tileEntity.connectedRight) {
@@ -135,17 +134,18 @@ public class TileEntityScreenRenderer extends TileEntitySpecialRenderer {
                 }
                 GL11.glTranslatef(-0.001F, -0.001F, -0.001F);
                 GL11.glScalef(1.002F, 1.002F, 1.002F);
-                getScreen1Quarter().renderAll();
+                screen1Quarter.renderAll();
                 break;
             case 4:
                 GL11.glTranslatef(-0.001F, -0.001F, -0.001F);
                 GL11.glScalef(1.002F, 1.002F, 1.002F);
-                getScreenOQuarter().renderAll();
+                screenOQuarter.renderAll();
                 break;
         }
         GL11.glPopMatrix();
 
-        GL11.glTranslatef(-tileEntity.screenOffsetx, this.yPlane, -tileEntity.screenOffsetz);
+        final float yPlane = 0.91F;
+        GL11.glTranslatef(-tileEntity.screenOffsetx, yPlane, -tileEntity.screenOffsetz);
         GL11.glRotatef(90, 1F, 0F, 0F);
         boolean cornerblock = false;
         if (tileEntity.connectionsLeft == 0 || tileEntity.connectionsRight == 0) {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityScreenRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityScreenRenderer.java
@@ -1,11 +1,15 @@
 package micdoodle8.mods.galacticraft.core.client.render.tile;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getScreen1Quarter;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getScreen2Quarter;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getScreen3Quarter;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getScreenOQuarter;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getWholeScreen;
+
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.client.model.AdvancedModelLoader;
-import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
 
@@ -14,12 +18,6 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.tile.TileEntityScreen;
-
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getScreen1Quarter;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getScreen2Quarter;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getScreen3Quarter;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getScreenOQuarter;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getWholeScreen;
 
 @SideOnly(Side.CLIENT)
 public class TileEntityScreenRenderer extends TileEntitySpecialRenderer {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityScreenRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityScreenRenderer.java
@@ -15,26 +15,22 @@ import cpw.mods.fml.relauncher.SideOnly;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.tile.TileEntityScreen;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getScreen1Quarter;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getScreen2Quarter;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getScreen3Quarter;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getScreenOQuarter;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getWholeScreen;
+
 @SideOnly(Side.CLIENT)
 public class TileEntityScreenRenderer extends TileEntitySpecialRenderer {
 
     public static final ResourceLocation blockTexture = new ResourceLocation(
             GalacticraftCore.ASSET_PREFIX,
             "textures/blocks/screenSide.png");
-    public static final IModelCustom screenModel0 = AdvancedModelLoader
-            .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/screenWhole.obj"));
-    public static final IModelCustom screenModel1 = AdvancedModelLoader
-            .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/screen3Quarters.obj"));
-    public static final IModelCustom screenModel2 = AdvancedModelLoader
-            .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/screen2Quarters.obj"));
-    public static final IModelCustom screenModel3 = AdvancedModelLoader
-            .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/screen1Quarters.obj"));
-    public static final IModelCustom screenModel4 = AdvancedModelLoader
-            .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/screen0Quarters.obj"));
+
     private final TextureManager renderEngine = FMLClientHandler.instance().getClient().renderEngine;
 
     private final float yPlane = 0.91F;
-    float frame = 0.098F;
 
     public void renderModelAt(TileEntityScreen tileEntity, double d, double d1, double d2, float f) {
         GL11.glPushMatrix();
@@ -96,7 +92,7 @@ public class TileEntityScreenRenderer extends TileEntitySpecialRenderer {
             case 0:
                 GL11.glTranslatef(-0.001F, -0.001F, -0.001F);
                 GL11.glScalef(1.002F, 1.002F, 1.002F);
-                TileEntityScreenRenderer.screenModel0.renderAll();
+                getWholeScreen().renderAll();
                 break;
             case 1:
                 if (tileEntity.connectedUp) {
@@ -111,7 +107,7 @@ public class TileEntityScreenRenderer extends TileEntitySpecialRenderer {
                 }
                 GL11.glTranslatef(-0.001F, -0.001F, -0.001F);
                 GL11.glScalef(1.002F, 1.002F, 1.002F);
-                TileEntityScreenRenderer.screenModel1.renderAll();
+                getScreen3Quarter().renderAll();
                 break;
             case 2:
                 if (!tileEntity.connectedRight && !tileEntity.connectedDown) {
@@ -126,7 +122,7 @@ public class TileEntityScreenRenderer extends TileEntitySpecialRenderer {
                 }
                 GL11.glTranslatef(-0.001F, -0.001F, -0.001F);
                 GL11.glScalef(1.002F, 1.002F, 1.002F);
-                TileEntityScreenRenderer.screenModel2.renderAll();
+                getScreen2Quarter().renderAll();
                 break;
             case 3:
                 if (!tileEntity.connectedRight) {
@@ -141,12 +137,12 @@ public class TileEntityScreenRenderer extends TileEntitySpecialRenderer {
                 }
                 GL11.glTranslatef(-0.001F, -0.001F, -0.001F);
                 GL11.glScalef(1.002F, 1.002F, 1.002F);
-                TileEntityScreenRenderer.screenModel3.renderAll();
+                getScreen1Quarter().renderAll();
                 break;
             case 4:
                 GL11.glTranslatef(-0.001F, -0.001F, -0.001F);
                 GL11.glScalef(1.002F, 1.002F, 1.002F);
-                TileEntityScreenRenderer.screenModel4.renderAll();
+                getScreenOQuarter().renderAll();
                 break;
         }
         GL11.glPopMatrix();

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityThrusterRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/tile/TileEntityThrusterRenderer.java
@@ -3,7 +3,6 @@ package micdoodle8.mods.galacticraft.core.client.render.tile;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.client.model.AdvancedModelLoader;
 import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
@@ -12,6 +11,7 @@ import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.core.tile.TileEntityThruster;
 
 @SideOnly(Side.CLIENT)
@@ -20,8 +20,7 @@ public class TileEntityThrusterRenderer extends TileEntitySpecialRenderer {
     public static final ResourceLocation thrusterTexture = new ResourceLocation(
             GalacticraftCore.ASSET_PREFIX,
             "textures/model/thruster.png");
-    public static final IModelCustom thrusterModel = AdvancedModelLoader
-            .loadModel(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "models/thruster.obj"));
+    private final IModelCustom thrusterModel = GalacticraftModels.getThruster();
 
     public void renderModelAt(TileEntityThruster tileEntity, double d, double d1, double d2, float f) {
         GL11.glPushMatrix();
@@ -66,7 +65,7 @@ public class TileEntityThrusterRenderer extends TileEntitySpecialRenderer {
             }
 
             GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-            TileEntityThrusterRenderer.thrusterModel.renderAll();
+            this.thrusterModel.renderAll();
         }
 
         GL11.glPopMatrix();

--- a/src/main/java/micdoodle8/mods/galacticraft/core/proxy/ClientProxyCore.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/proxy/ClientProxyCore.java
@@ -291,9 +291,8 @@ public class ClientProxyCore extends CommonProxyCore {
     }
 
     public static void registerEntityRenderers() {
-        RenderingRegistry.registerEntityRenderingHandler(
-                EntityTier1Rocket.class,
-                new RenderTier1Rocket(new ModelRocketTier1(), GalacticraftCore.ASSET_PREFIX, "rocketT1"));
+        // spotless:off
+        RenderingRegistry.registerEntityRenderingHandler(EntityTier1Rocket.class, new RenderTier1Rocket(new ModelRocketTier1(), GalacticraftCore.ASSET_PREFIX, "rocketT1"));
         RenderingRegistry.registerEntityRenderingHandler(EntityEvolvedSpider.class, new RenderEvolvedSpider());
         RenderingRegistry.registerEntityRenderingHandler(EntityEvolvedZombie.class, new RenderEvolvedZombie());
         RenderingRegistry.registerEntityRenderingHandler(EntityEvolvedCreeper.class, new RenderEvolvedCreeper());
@@ -318,29 +317,21 @@ public class ClientProxyCore extends CommonProxyCore {
             RenderingRegistry.registerEntityRenderingHandler(EntityPlayerSP.class, new RenderPlayerGC());
             RenderingRegistry.registerEntityRenderingHandler(EntityOtherPlayerMP.class, new RenderPlayerGC());
         }
+        // spotless:on
     }
 
     public static void registerItemRenderers() {
-        MinecraftForgeClient
-                .registerItemRenderer(Item.getItemFromBlock(GCBlocks.unlitTorch), new ItemRendererUnlitTorch());
-        MinecraftForgeClient.registerItemRenderer(
-                GCItems.rocketTier1,
-                new ItemRendererTier1Rocket(
-                        new EntityTier1Rocket(ClientProxyCore.mc.theWorld),
-                        new ModelRocketTier1(),
-                        new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "textures/model/rocketT1.png")));
+        // spotless:off
+        MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(GCBlocks.unlitTorch), new ItemRendererUnlitTorch());
+        MinecraftForgeClient.registerItemRenderer(GCItems.rocketTier1, new ItemRendererTier1Rocket(new EntityTier1Rocket(ClientProxyCore.mc.theWorld), new ModelRocketTier1(), new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "textures/model/rocketT1.png")));
         MinecraftForgeClient.registerItemRenderer(GCItems.buggy, new ItemRendererBuggy());
         MinecraftForgeClient.registerItemRenderer(GCItems.flag, new ItemRendererFlag());
-        MinecraftForgeClient.registerItemRenderer(
-                GCItems.key,
-                new ItemRendererKey(
-                        new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "textures/model/treasure.png")));
+        MinecraftForgeClient.registerItemRenderer(GCItems.key, new ItemRendererKey(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "textures/model/treasure.png")));
         MinecraftForgeClient.registerItemRenderer(GCItems.meteorChunk, new ItemRendererMeteorChunk());
-        MinecraftForgeClient
-                .registerItemRenderer(Item.getItemFromBlock(GCBlocks.spinThruster), new ItemRendererThruster());
-        MinecraftForgeClient
-                .registerItemRenderer(Item.getItemFromBlock(GCBlocks.brightLamp), new ItemRendererArclamp());
+        MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(GCBlocks.spinThruster), new ItemRendererThruster());
+        MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(GCBlocks.brightLamp), new ItemRendererArclamp());
         MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(GCBlocks.screen), new ItemRendererScreen());
+        // spotless:on
     }
 
     public static void registerHandlers() {
@@ -355,24 +346,22 @@ public class ClientProxyCore extends CommonProxyCore {
     }
 
     public static void registerTileEntityRenderers() {
-        ClientRegistry
-                .bindTileEntitySpecialRenderer(TileEntityAluminumWire.class, new TileEntityAluminumWireRenderer());
-        ClientRegistry
-                .bindTileEntitySpecialRenderer(TileEntityTreasureChest.class, new TileEntityTreasureChestRenderer());
+        // spotless:off
+        ClientRegistry.bindTileEntitySpecialRenderer(TileEntityAluminumWire.class, new TileEntityAluminumWireRenderer());
+        ClientRegistry.bindTileEntitySpecialRenderer(TileEntityTreasureChest.class, new TileEntityTreasureChestRenderer());
         ClientRegistry.bindTileEntitySpecialRenderer(TileEntityParaChest.class, new TileEntityParachestRenderer());
-        ClientRegistry
-                .bindTileEntitySpecialRenderer(TileEntityNasaWorkbench.class, new TileEntityNasaWorkbenchRenderer());
+        ClientRegistry.bindTileEntitySpecialRenderer(TileEntityNasaWorkbench.class, new TileEntityNasaWorkbenchRenderer());
         ClientRegistry.bindTileEntitySpecialRenderer(TileEntitySolar.class, new TileEntitySolarPanelRenderer());
-        ClientRegistry.bindTileEntitySpecialRenderer(
-                TileEntityOxygenDistributor.class,
-                new TileEntityBubbleProviderRenderer(0.25F, 0.25F, 1.0F));
+        ClientRegistry.bindTileEntitySpecialRenderer(TileEntityOxygenDistributor.class, new TileEntityBubbleProviderRenderer(0.25F, 0.25F, 1.0F));
         ClientRegistry.bindTileEntitySpecialRenderer(TileEntityDish.class, new TileEntityDishRenderer());
         ClientRegistry.bindTileEntitySpecialRenderer(TileEntityThruster.class, new TileEntityThrusterRenderer());
         ClientRegistry.bindTileEntitySpecialRenderer(TileEntityArclamp.class, new TileEntityArclampRenderer());
         ClientRegistry.bindTileEntitySpecialRenderer(TileEntityScreen.class, new TileEntityScreenRenderer());
+        // spotless:on
     }
 
     public static void registerBlockHandlers() {
+        // spotless:off
         ClientProxyCore.renderIdTreasureChest = RenderingRegistry.getNextAvailableRenderId();
         ClientProxyCore.renderIdTorchUnlit = RenderingRegistry.getNextAvailableRenderId();
         ClientProxyCore.renderIdBreathableAir = RenderingRegistry.getNextAvailableRenderId();
@@ -391,6 +380,7 @@ public class ClientProxyCore extends CommonProxyCore {
         RenderingRegistry.registerBlockHandler(new BlockRendererNasaWorkbench(ClientProxyCore.renderIdCraftingTable));
         RenderingRegistry.registerBlockHandler(new BlockRendererLandingPad(ClientProxyCore.renderIdLandingPad));
         RenderingRegistry.registerBlockHandler(new BlockRendererMachine(ClientProxyCore.renderIdMachine));
+        // spotless:on
     }
 
     public static void registerInventoryTabs() {

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/AsteroidsModuleClient.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/AsteroidsModuleClient.java
@@ -75,65 +75,46 @@ public class AsteroidsModuleClient implements IPlanetsModuleClient {
 
     @Override
     public void init(FMLInitializationEvent event) {
+        // spotless:off
         AsteroidsModuleClient.walkwayRenderID = RenderingRegistry.getNextAvailableRenderId();
         RenderingRegistry.registerBlockHandler(new BlockRendererWalkway(AsteroidsModuleClient.walkwayRenderID));
         AsteroidsModuleClient.treasureChestID = RenderingRegistry.getNextAvailableRenderId();
-        RenderingRegistry
-                .registerBlockHandler(new BlockRendererTier3TreasureChest(AsteroidsModuleClient.treasureChestID));
+        RenderingRegistry.registerBlockHandler(new BlockRendererTier3TreasureChest(AsteroidsModuleClient.treasureChestID));
         final AsteroidsEventHandlerClient clientEventHandler = new AsteroidsEventHandlerClient();
         FMLCommonHandler.instance().bus().register(clientEventHandler);
         MinecraftForge.EVENT_BUS.register(clientEventHandler);
         FluidTexturesGC.init();
+        // spotless:on
     }
 
     @Override
     public void postInit(FMLPostInitializationEvent event) {
+        // spotless:off
         RenderingRegistry.registerEntityRenderingHandler(EntitySmallAsteroid.class, new RenderSmallAsteroid());
         RenderingRegistry.registerEntityRenderingHandler(EntityGrapple.class, new RenderGrapple());
-        final IModelCustom podModel = AdvancedModelLoader
-                .loadModel(new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "models/pod.obj"));
+        final IModelCustom podModel = AdvancedModelLoader.loadModel(new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "models/pod.obj"));
         RenderingRegistry.registerEntityRenderingHandler(EntityEntryPod.class, new RenderEntryPod(podModel));
-        final IModelCustom rocketModel = AdvancedModelLoader
-                .loadModel(new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "models/tier3rocket.obj"));
-        RenderingRegistry.registerEntityRenderingHandler(
-                EntityTier3Rocket.class,
-                new RenderTier3Rocket(rocketModel, AsteroidsModule.ASSET_PREFIX, "tier3rocket"));
+        final IModelCustom rocketModel = AdvancedModelLoader.loadModel(new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "models/tier3rocket.obj"));
+        RenderingRegistry.registerEntityRenderingHandler(EntityTier3Rocket.class, new RenderTier3Rocket(rocketModel, AsteroidsModule.ASSET_PREFIX, "tier3rocket"));
         RenderingRegistry.registerEntityRenderingHandler(EntityAstroMiner.class, new RenderAstroMiner());
-        final IModelCustom grappleModel = AdvancedModelLoader
-                .loadModel(new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "models/grapple.obj"));
+        final IModelCustom grappleModel = AdvancedModelLoader.loadModel(new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "models/grapple.obj"));
         MinecraftForgeClient.registerItemRenderer(AsteroidsItems.grapple, new ItemRendererGrappleHook(grappleModel));
-        MinecraftForgeClient.registerItemRenderer(
-                Item.getItemFromBlock(AsteroidBlocks.beamReceiver),
-                new ItemRendererBeamReceiver());
-        MinecraftForgeClient.registerItemRenderer(
-                Item.getItemFromBlock(AsteroidBlocks.beamReflector),
-                new ItemRendererBeamReflector());
+        MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(AsteroidBlocks.beamReceiver), new ItemRendererBeamReceiver());
+        MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(AsteroidBlocks.beamReflector), new ItemRendererBeamReflector());
         MinecraftForgeClient.registerItemRenderer(AsteroidsItems.tier3Rocket, new ItemRendererTier3Rocket(rocketModel));
         MinecraftForgeClient.registerItemRenderer(AsteroidsItems.astroMiner, new ItemRendererAstroMiner());
         MinecraftForgeClient.registerItemRenderer(AsteroidsItems.thermalPadding, new ItemRendererThermalArmor());
-        MinecraftForgeClient.registerItemRenderer(
-                Item.getItemFromBlock(AsteroidBlocks.shortRangeTelepad),
-                new ItemRendererShortRangeTelepad());
+        MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(AsteroidBlocks.shortRangeTelepad), new ItemRendererShortRangeTelepad());
         MinecraftForgeClient.registerItemRenderer(AsteroidsItems.heavyNoseCone, new ItemRendererHeavyNoseCone());
-        MinecraftForgeClient
-                .registerItemRenderer(Item.getItemFromBlock(AsteroidBlocks.blockWalkway), new ItemRendererWalkway());
-        MinecraftForgeClient.registerItemRenderer(
-                Item.getItemFromBlock(AsteroidBlocks.blockWalkwayOxygenPipe),
-                new ItemRendererWalkway());
-        MinecraftForgeClient.registerItemRenderer(
-                Item.getItemFromBlock(AsteroidBlocks.blockWalkwayWire),
-                new ItemRendererWalkway());
-        ClientRegistry
-                .bindTileEntitySpecialRenderer(TileEntityBeamReflector.class, new TileEntityBeamReflectorRenderer());
-        ClientRegistry
-                .bindTileEntitySpecialRenderer(TileEntityBeamReceiver.class, new TileEntityBeamReceiverRenderer());
+        MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(AsteroidBlocks.blockWalkway), new ItemRendererWalkway());
+        MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(AsteroidBlocks.blockWalkwayOxygenPipe), new ItemRendererWalkway());
+        MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(AsteroidBlocks.blockWalkwayWire), new ItemRendererWalkway());
+        ClientRegistry.bindTileEntitySpecialRenderer(TileEntityBeamReflector.class, new TileEntityBeamReflectorRenderer());
+        ClientRegistry.bindTileEntitySpecialRenderer(TileEntityBeamReceiver.class, new TileEntityBeamReceiverRenderer());
         ClientRegistry.bindTileEntitySpecialRenderer(TileEntityMinerBase.class, new TileEntityMinerBaseRenderer());
-        ClientRegistry.bindTileEntitySpecialRenderer(
-                TileEntityShortRangeTelepad.class,
-                new TileEntityShortRangeTelepadRenderer());
-        ClientRegistry.bindTileEntitySpecialRenderer(
-                TileEntityTreasureChestAsteroids.class,
-                new TileEntityTreasureChestRenderer());
+        ClientRegistry.bindTileEntitySpecialRenderer(TileEntityShortRangeTelepad.class, new TileEntityShortRangeTelepadRenderer());
+        ClientRegistry.bindTileEntitySpecialRenderer(TileEntityTreasureChestAsteroids.class, new TileEntityTreasureChestRenderer());
+        // spotless:on
     }
 
     @Override

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/AsteroidsModuleClient.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/AsteroidsModuleClient.java
@@ -1,5 +1,9 @@
 package micdoodle8.mods.galacticraft.planets.asteroids;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getGrapple;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getPod;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getRocketT3;
+
 import java.util.List;
 
 import net.minecraft.block.Block;
@@ -62,10 +66,6 @@ import micdoodle8.mods.galacticraft.planets.asteroids.tile.TileEntityBeamReflect
 import micdoodle8.mods.galacticraft.planets.asteroids.tile.TileEntityMinerBase;
 import micdoodle8.mods.galacticraft.planets.asteroids.tile.TileEntityShortRangeTelepad;
 import micdoodle8.mods.galacticraft.planets.asteroids.tile.TileEntityTreasureChestAsteroids;
-
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getGrapple;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getPod;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getRocketT3;
 
 public class AsteroidsModuleClient implements IPlanetsModuleClient {
 

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/AsteroidsModuleClient.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/AsteroidsModuleClient.java
@@ -8,10 +8,8 @@ import net.minecraft.client.particle.EntityFX;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.client.MinecraftForgeClient;
-import net.minecraftforge.client.model.AdvancedModelLoader;
 import net.minecraftforge.client.model.IModelCustom;
 import net.minecraftforge.common.MinecraftForge;
 
@@ -65,6 +63,10 @@ import micdoodle8.mods.galacticraft.planets.asteroids.tile.TileEntityMinerBase;
 import micdoodle8.mods.galacticraft.planets.asteroids.tile.TileEntityShortRangeTelepad;
 import micdoodle8.mods.galacticraft.planets.asteroids.tile.TileEntityTreasureChestAsteroids;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getGrapple;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getPod;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getRocketT3;
+
 public class AsteroidsModuleClient implements IPlanetsModuleClient {
 
     private static int walkwayRenderID;
@@ -92,12 +94,12 @@ public class AsteroidsModuleClient implements IPlanetsModuleClient {
         // spotless:off
         RenderingRegistry.registerEntityRenderingHandler(EntitySmallAsteroid.class, new RenderSmallAsteroid());
         RenderingRegistry.registerEntityRenderingHandler(EntityGrapple.class, new RenderGrapple());
-        final IModelCustom podModel = AdvancedModelLoader.loadModel(new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "models/pod.obj"));
+        final IModelCustom podModel = getPod();
         RenderingRegistry.registerEntityRenderingHandler(EntityEntryPod.class, new RenderEntryPod(podModel));
-        final IModelCustom rocketModel = AdvancedModelLoader.loadModel(new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "models/tier3rocket.obj"));
+        final IModelCustom rocketModel = getRocketT3();
         RenderingRegistry.registerEntityRenderingHandler(EntityTier3Rocket.class, new RenderTier3Rocket(rocketModel, AsteroidsModule.ASSET_PREFIX, "tier3rocket"));
         RenderingRegistry.registerEntityRenderingHandler(EntityAstroMiner.class, new RenderAstroMiner());
-        final IModelCustom grappleModel = AdvancedModelLoader.loadModel(new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "models/grapple.obj"));
+        final IModelCustom grappleModel = getGrapple();
         MinecraftForgeClient.registerItemRenderer(AsteroidsItems.grapple, new ItemRendererGrappleHook(grappleModel));
         MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(AsteroidBlocks.beamReceiver), new ItemRendererBeamReceiver());
         MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(AsteroidBlocks.beamReflector), new ItemRendererBeamReflector());

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/AsteroidsModuleClient.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/AsteroidsModuleClient.java
@@ -1,9 +1,5 @@
 package micdoodle8.mods.galacticraft.planets.asteroids;
 
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getGrapple;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getPod;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getRocketT3;
-
 import java.util.List;
 
 import net.minecraft.block.Block;
@@ -26,6 +22,7 @@ import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.relauncher.Side;
 import micdoodle8.mods.galacticraft.api.vector.Vector3;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.planets.GuiIdsPlanets;
 import micdoodle8.mods.galacticraft.planets.IPlanetsModuleClient;
 import micdoodle8.mods.galacticraft.planets.asteroids.blocks.AsteroidBlocks;
@@ -94,12 +91,12 @@ public class AsteroidsModuleClient implements IPlanetsModuleClient {
         // spotless:off
         RenderingRegistry.registerEntityRenderingHandler(EntitySmallAsteroid.class, new RenderSmallAsteroid());
         RenderingRegistry.registerEntityRenderingHandler(EntityGrapple.class, new RenderGrapple());
-        final IModelCustom podModel = getPod();
+        final IModelCustom podModel = GalacticraftModels.getPod();
         RenderingRegistry.registerEntityRenderingHandler(EntityEntryPod.class, new RenderEntryPod(podModel));
-        final IModelCustom rocketModel = getRocketT3();
+        final IModelCustom rocketModel = GalacticraftModels.getRocketT3();
         RenderingRegistry.registerEntityRenderingHandler(EntityTier3Rocket.class, new RenderTier3Rocket(rocketModel, AsteroidsModule.ASSET_PREFIX, "tier3rocket"));
         RenderingRegistry.registerEntityRenderingHandler(EntityAstroMiner.class, new RenderAstroMiner());
-        final IModelCustom grappleModel = getGrapple();
+        final IModelCustom grappleModel = GalacticraftModels.getGrapple();
         MinecraftForgeClient.registerItemRenderer(AsteroidsItems.grapple, new ItemRendererGrappleHook(grappleModel));
         MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(AsteroidBlocks.beamReceiver), new ItemRendererBeamReceiver());
         MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(AsteroidBlocks.beamReflector), new ItemRendererBeamReflector());

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/entity/RenderAstroMiner.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/entity/RenderAstroMiner.java
@@ -1,5 +1,12 @@
 package micdoodle8.mods.galacticraft.planets.asteroids.client.render.entity;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMiner;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerBottomLaser;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerCenterLaser;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerFrontLaser;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerLeftLaserGuard;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerRightLaserGuard;
+
 import java.util.ArrayList;
 import java.util.Random;
 
@@ -9,7 +16,6 @@ import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
@@ -21,23 +27,24 @@ import micdoodle8.mods.galacticraft.core.perlin.generator.Gradient;
 import micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule;
 import micdoodle8.mods.galacticraft.planets.asteroids.entities.EntityAstroMiner;
 
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMiner;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerFrontLaser;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerBottomLaser;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerCenterLaser;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerLeftLaserGuard;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerRightLaserGuard;
-
 public class RenderAstroMiner extends Render {
 
     private static final float LSIZE = 0.12F;
     private static final float RETRACTIONSPEED = 0.02F;
     private float lastPartTime;
 
-    public static ResourceLocation scanTexture = new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "textures/misc/gradient.png");
-    public static ResourceLocation modelTexture = new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "textures/model/astroMiner.png");
-    public static ResourceLocation modelTextureFX = new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "textures/model/astroMinerFX.png");
-    public static ResourceLocation modelTextureOff = new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "textures/model/astroMiner_off.png");
+    public static ResourceLocation scanTexture = new ResourceLocation(
+            AsteroidsModule.ASSET_PREFIX,
+            "textures/misc/gradient.png");
+    public static ResourceLocation modelTexture = new ResourceLocation(
+            AsteroidsModule.ASSET_PREFIX,
+            "textures/model/astroMiner.png");
+    public static ResourceLocation modelTextureFX = new ResourceLocation(
+            AsteroidsModule.ASSET_PREFIX,
+            "textures/model/astroMinerFX.png");
+    public static ResourceLocation modelTextureOff = new ResourceLocation(
+            AsteroidsModule.ASSET_PREFIX,
+            "textures/model/astroMiner_off.png");
 
     private final NoiseModule wobbleX;
     private final NoiseModule wobbleY;

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/entity/RenderAstroMiner.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/entity/RenderAstroMiner.java
@@ -9,7 +9,6 @@ import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.client.model.AdvancedModelLoader;
 import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
@@ -22,22 +21,23 @@ import micdoodle8.mods.galacticraft.core.perlin.generator.Gradient;
 import micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule;
 import micdoodle8.mods.galacticraft.planets.asteroids.entities.EntityAstroMiner;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMiner;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerFrontLaser;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerBottomLaser;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerCenterLaser;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerLeftLaserGuard;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerRightLaserGuard;
+
 public class RenderAstroMiner extends Render {
 
     private static final float LSIZE = 0.12F;
     private static final float RETRACTIONSPEED = 0.02F;
     private float lastPartTime;
 
-    public static ResourceLocation scanTexture;
-    public static ResourceLocation modelTexture;
-    public static ResourceLocation modelTextureFX;
-    public static ResourceLocation modelTextureOff;
-    public static IModelCustom modelObj;
-    public static IModelCustom modellaser1;
-    public static IModelCustom modellaser2;
-    public static IModelCustom modellaser3;
-    public static IModelCustom modellasergl;
-    public static IModelCustom modellasergr;
+    public static ResourceLocation scanTexture = new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "textures/misc/gradient.png");
+    public static ResourceLocation modelTexture = new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "textures/model/astroMiner.png");
+    public static ResourceLocation modelTextureFX = new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "textures/model/astroMinerFX.png");
+    public static ResourceLocation modelTextureOff = new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "textures/model/astroMiner_off.png");
 
     private final NoiseModule wobbleX;
     private final NoiseModule wobbleY;
@@ -45,25 +45,6 @@ public class RenderAstroMiner extends Render {
     private final NoiseModule wobbleXX;
     private final NoiseModule wobbleYY;
     private final NoiseModule wobbleZZ;
-
-    static {
-        modelObj = AdvancedModelLoader
-                .loadModel(new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "models/astroMiner.obj"));
-        modellaser1 = AdvancedModelLoader
-                .loadModel(new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "models/astroMinerLaserFront.obj"));
-        modellaser2 = AdvancedModelLoader
-                .loadModel(new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "models/astroMinerLaserBottom.obj"));
-        modellaser3 = AdvancedModelLoader
-                .loadModel(new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "models/astroMinerLaserCenter.obj"));
-        modellasergl = AdvancedModelLoader
-                .loadModel(new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "models/astroMinerLeftGuard.obj"));
-        modellasergr = AdvancedModelLoader
-                .loadModel(new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "models/astroMinerRightGuard.obj"));
-        modelTexture = new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "textures/model/astroMiner.png");
-        modelTextureFX = new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "textures/model/astroMinerFX.png");
-        modelTextureOff = new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "textures/model/astroMiner_off.png");
-        scanTexture = new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "textures/misc/gradient.png");
-    }
 
     public RenderAstroMiner() {
         this.shadowSize = 2F;
@@ -150,7 +131,7 @@ public class RenderAstroMiner extends Render {
 
         if (active) {
             FMLClientHandler.instance().getClient().renderEngine.bindTexture(RenderAstroMiner.modelTexture);
-            RenderAstroMiner.modelObj.renderAllExcept(
+            getAstroMiner().renderAllExcept(
                     "Hoverpad_Front_Left_Top",
                     "Hoverpad_Front_Right_Top",
                     "Hoverpad_Front_Left_Bottom",
@@ -177,7 +158,7 @@ public class RenderAstroMiner extends Render {
             OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240F, 240F);
             GL11.glDisable(GL11.GL_LIGHTING);
             GL11.glColor4f(sinOfTheTime, sinOfTheTime, sinOfTheTime, 1.0F);
-            RenderAstroMiner.modelObj.renderOnly(
+            getAstroMiner().renderOnly(
                     "Hoverpad_Front_Left_Top",
                     "Hoverpad_Front_Right_Top",
                     "Hoverpad_Front_Left_Bottom",
@@ -197,7 +178,7 @@ public class RenderAstroMiner extends Render {
             GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_LINEAR);
             GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_LINEAR);
             GL11.glColor4f(sinOfTheTime, sinOfTheTime, sinOfTheTime, 0.6F);
-            RenderAstroMiner.modelObj.renderOnly(
+            getAstroMiner().renderOnly(
                     "Hoverpad_Front_Left_Top_Glow",
                     "Hoverpad_Front_Right_Top_Glow",
                     "Hoverpad_Front_Left_Bottom_Glow",
@@ -281,7 +262,7 @@ public class RenderAstroMiner extends Render {
             OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, lightMapSaveX, lightMapSaveY);
         } else {
             this.bindEntityTexture(astroMiner);
-            RenderAstroMiner.modelObj.renderAllExcept(
+            getAstroMiner().renderAllExcept(
                     "Hoverpad_Front_Left_Top_Glow",
                     "Hoverpad_Front_Right_Top_Glow",
                     "Hoverpad_Front_Left_Bottom_Glow",
@@ -527,19 +508,19 @@ public class RenderAstroMiner extends Render {
             zadjust = (zadjust - yadjust) * 2.5F + yadjust;
         }
         GL11.glTranslatef(0F, yadjust, zadjust);
-        RenderAstroMiner.modellaser1.renderAll();
-        RenderAstroMiner.modellaser2.renderAll();
+        getAstroMinerFrontLaser().renderAll();
+        getAstroMinerBottomLaser().renderAll();
         if (yadjust == 0.938F) {
             // Do not move laser centre into body
             GL11.glTranslatef(0F, 0F, -zadjust + 0.938F);
         }
-        RenderAstroMiner.modellaser3.renderAll();
+        getAstroMinerCenterLaser().renderAll();
         GL11.glPopMatrix();
         GL11.glPushMatrix();
         GL11.glTranslatef(guardmovement, 0F, 0F);
-        RenderAstroMiner.modellasergl.renderAll();
+        getAstroMinerLeftLaserGuard().renderAll();
         GL11.glTranslatef(-2 * guardmovement, 0F, 0F);
-        RenderAstroMiner.modellasergr.renderAll();
+        getAstroMinerRightLaserGuard().renderAll();
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/entity/RenderAstroMiner.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/entity/RenderAstroMiner.java
@@ -1,12 +1,5 @@
 package micdoodle8.mods.galacticraft.planets.asteroids.client.render.entity;
 
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMiner;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerBottomLaser;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerCenterLaser;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerFrontLaser;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerLeftLaserGuard;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerRightLaserGuard;
-
 import java.util.ArrayList;
 import java.util.Random;
 
@@ -16,12 +9,14 @@ import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
 import cpw.mods.fml.client.FMLClientHandler;
 import micdoodle8.mods.galacticraft.api.vector.BlockVec3;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.core.perlin.NoiseModule;
 import micdoodle8.mods.galacticraft.core.perlin.generator.Gradient;
 import micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule;
@@ -31,6 +26,12 @@ public class RenderAstroMiner extends Render {
 
     private static final float LSIZE = 0.12F;
     private static final float RETRACTIONSPEED = 0.02F;
+    private final IModelCustom astroMiner = GalacticraftModels.getAstroMiner();
+    private final IModelCustom astroMinerFrontLaser = GalacticraftModels.getAstroMinerFrontLaser();
+    private final IModelCustom astroMinerBottomLaser = GalacticraftModels.getAstroMinerBottomLaser();
+    private final IModelCustom astroMinerCenterLaser = GalacticraftModels.getAstroMinerCenterLaser();
+    private final IModelCustom astroMinerLeftLaserGuard = GalacticraftModels.getAstroMinerLeftLaserGuard();
+    private final IModelCustom astroMinerRightLaserGuard = GalacticraftModels.getAstroMinerRightLaserGuard();
     private float lastPartTime;
 
     public static ResourceLocation scanTexture = new ResourceLocation(
@@ -138,7 +139,7 @@ public class RenderAstroMiner extends Render {
 
         if (active) {
             FMLClientHandler.instance().getClient().renderEngine.bindTexture(RenderAstroMiner.modelTexture);
-            getAstroMiner().renderAllExcept(
+            this.astroMiner.renderAllExcept(
                     "Hoverpad_Front_Left_Top",
                     "Hoverpad_Front_Right_Top",
                     "Hoverpad_Front_Left_Bottom",
@@ -165,7 +166,7 @@ public class RenderAstroMiner extends Render {
             OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240F, 240F);
             GL11.glDisable(GL11.GL_LIGHTING);
             GL11.glColor4f(sinOfTheTime, sinOfTheTime, sinOfTheTime, 1.0F);
-            getAstroMiner().renderOnly(
+            this.astroMiner.renderOnly(
                     "Hoverpad_Front_Left_Top",
                     "Hoverpad_Front_Right_Top",
                     "Hoverpad_Front_Left_Bottom",
@@ -185,7 +186,7 @@ public class RenderAstroMiner extends Render {
             GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_LINEAR);
             GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_LINEAR);
             GL11.glColor4f(sinOfTheTime, sinOfTheTime, sinOfTheTime, 0.6F);
-            getAstroMiner().renderOnly(
+            this.astroMiner.renderOnly(
                     "Hoverpad_Front_Left_Top_Glow",
                     "Hoverpad_Front_Right_Top_Glow",
                     "Hoverpad_Front_Left_Bottom_Glow",
@@ -269,7 +270,7 @@ public class RenderAstroMiner extends Render {
             OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, lightMapSaveX, lightMapSaveY);
         } else {
             this.bindEntityTexture(astroMiner);
-            getAstroMiner().renderAllExcept(
+            this.astroMiner.renderAllExcept(
                     "Hoverpad_Front_Left_Top_Glow",
                     "Hoverpad_Front_Right_Top_Glow",
                     "Hoverpad_Front_Left_Bottom_Glow",
@@ -515,19 +516,19 @@ public class RenderAstroMiner extends Render {
             zadjust = (zadjust - yadjust) * 2.5F + yadjust;
         }
         GL11.glTranslatef(0F, yadjust, zadjust);
-        getAstroMinerFrontLaser().renderAll();
-        getAstroMinerBottomLaser().renderAll();
+        astroMinerFrontLaser.renderAll();
+        astroMinerBottomLaser.renderAll();
         if (yadjust == 0.938F) {
             // Do not move laser centre into body
             GL11.glTranslatef(0F, 0F, -zadjust + 0.938F);
         }
-        getAstroMinerCenterLaser().renderAll();
+        astroMinerCenterLaser.renderAll();
         GL11.glPopMatrix();
         GL11.glPushMatrix();
         GL11.glTranslatef(guardmovement, 0F, 0F);
-        getAstroMinerLeftLaserGuard().renderAll();
+        astroMinerLeftLaserGuard.renderAll();
         GL11.glTranslatef(-2 * guardmovement, 0F, 0F);
-        getAstroMinerRightLaserGuard().renderAll();
+        astroMinerRightLaserGuard.renderAll();
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererAstroMiner.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererAstroMiner.java
@@ -6,7 +6,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.IItemRenderer;
-import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.Sys;
 import org.lwjgl.opengl.GL11;
@@ -15,22 +14,19 @@ import cpw.mods.fml.client.FMLClientHandler;
 import micdoodle8.mods.galacticraft.api.prefab.entity.EntityAutoRocket;
 import micdoodle8.mods.galacticraft.core.entities.EntityLanderBase;
 import micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule;
-import micdoodle8.mods.galacticraft.planets.asteroids.client.render.entity.RenderAstroMiner;
+
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMiner;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerLeftLaserGuard;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerRightLaserGuard;
 
 public class ItemRendererAstroMiner implements IItemRenderer {
 
-    protected IModelCustom modelMiner;
-    protected IModelCustom modellasergl;
-    protected IModelCustom modellasergr;
     protected static RenderItem drawItems = new RenderItem();
     protected ResourceLocation texture = new ResourceLocation(
             AsteroidsModule.ASSET_PREFIX,
             "textures/model/astroMiner_off.png");
 
     public ItemRendererAstroMiner() {
-        this.modelMiner = RenderAstroMiner.modelObj;
-        this.modellasergl = RenderAstroMiner.modellasergl;
-        this.modellasergr = RenderAstroMiner.modellasergr;
     }
 
     protected void renderMiner(ItemRenderType type, RenderBlocks render, ItemStack item, float translateX,
@@ -43,11 +39,11 @@ public class ItemRendererAstroMiner implements IItemRenderer {
         GL11.glScalef(0.06F, 0.06F, 0.06F);
 
         FMLClientHandler.instance().getClient().renderEngine.bindTexture(this.texture);
-        this.modelMiner.renderAll();
+        getAstroMiner().renderAll();
         GL11.glTranslatef(1.875F, 0F, 0F);
-        this.modellasergl.renderAll();
+        getAstroMinerLeftLaserGuard().renderAll();
         GL11.glTranslatef(-3.75F, 0F, 0F);
-        this.modellasergr.renderAll();
+        getAstroMinerRightLaserGuard().renderAll();
         GL11.glPopMatrix();
         if (!saveCullState) {
             GL11.glDisable(GL11.GL_CULL_FACE);

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererAstroMiner.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererAstroMiner.java
@@ -1,27 +1,26 @@
 package micdoodle8.mods.galacticraft.planets.asteroids.client.render.item;
 
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMiner;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerLeftLaserGuard;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerRightLaserGuard;
-
 import net.minecraft.client.renderer.RenderBlocks;
-import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.IItemRenderer;
+import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.Sys;
 import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.client.FMLClientHandler;
 import micdoodle8.mods.galacticraft.api.prefab.entity.EntityAutoRocket;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.core.entities.EntityLanderBase;
 import micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule;
 
 public class ItemRendererAstroMiner implements IItemRenderer {
 
-    protected static RenderItem drawItems = new RenderItem();
+    private final IModelCustom astroMiner = GalacticraftModels.getAstroMiner();
+    private final IModelCustom astroMinerLeftLaserGuard = GalacticraftModels.getAstroMinerLeftLaserGuard();
+    private final IModelCustom astroMinerRightLaserGuard = GalacticraftModels.getAstroMinerRightLaserGuard();
     protected ResourceLocation texture = new ResourceLocation(
             AsteroidsModule.ASSET_PREFIX,
             "textures/model/astroMiner_off.png");
@@ -38,11 +37,11 @@ public class ItemRendererAstroMiner implements IItemRenderer {
         GL11.glScalef(0.06F, 0.06F, 0.06F);
 
         FMLClientHandler.instance().getClient().renderEngine.bindTexture(this.texture);
-        getAstroMiner().renderAll();
+        astroMiner.renderAll();
         GL11.glTranslatef(1.875F, 0F, 0F);
-        getAstroMinerLeftLaserGuard().renderAll();
+        astroMinerLeftLaserGuard.renderAll();
         GL11.glTranslatef(-3.75F, 0F, 0F);
-        getAstroMinerRightLaserGuard().renderAll();
+        astroMinerRightLaserGuard.renderAll();
         GL11.glPopMatrix();
         if (!saveCullState) {
             GL11.glDisable(GL11.GL_CULL_FACE);

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererAstroMiner.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererAstroMiner.java
@@ -1,5 +1,9 @@
 package micdoodle8.mods.galacticraft.planets.asteroids.client.render.item;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMiner;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerLeftLaserGuard;
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerRightLaserGuard;
+
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.entity.player.EntityPlayer;
@@ -15,10 +19,6 @@ import micdoodle8.mods.galacticraft.api.prefab.entity.EntityAutoRocket;
 import micdoodle8.mods.galacticraft.core.entities.EntityLanderBase;
 import micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule;
 
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMiner;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerLeftLaserGuard;
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getAstroMinerRightLaserGuard;
-
 public class ItemRendererAstroMiner implements IItemRenderer {
 
     protected static RenderItem drawItems = new RenderItem();
@@ -26,8 +26,7 @@ public class ItemRendererAstroMiner implements IItemRenderer {
             AsteroidsModule.ASSET_PREFIX,
             "textures/model/astroMiner_off.png");
 
-    public ItemRendererAstroMiner() {
-    }
+    public ItemRendererAstroMiner() {}
 
     protected void renderMiner(ItemRenderType type, RenderBlocks render, ItemStack item, float translateX,
             float translateY, float translateZ) {

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererBeamReceiver.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererBeamReceiver.java
@@ -9,6 +9,8 @@ import org.lwjgl.opengl.GL11;
 import cpw.mods.fml.client.FMLClientHandler;
 import micdoodle8.mods.galacticraft.planets.asteroids.client.render.tile.TileEntityBeamReceiverRenderer;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getBeamReceiver;
+
 public class ItemRendererBeamReceiver implements IItemRenderer {
 
     private void renderBeamReceiver(ItemRenderType type) {
@@ -19,14 +21,14 @@ public class ItemRendererBeamReceiver implements IItemRenderer {
 
         FMLClientHandler.instance().getClient().renderEngine
                 .bindTexture(TileEntityBeamReceiverRenderer.receiverTexture);
-        TileEntityBeamReceiverRenderer.receiverModel.renderPart("Main");
-        TileEntityBeamReceiverRenderer.receiverModel.renderPart("Ring");
+        getBeamReceiver().renderPart("Main");
+        getBeamReceiver().renderPart("Ring");
 
         GL11.glColor3f(0.6F, 0.3F, 0.0F);
 
         GL11.glDisable(GL11.GL_TEXTURE_2D);
         GL11.glDisable(GL11.GL_CULL_FACE);
-        TileEntityBeamReceiverRenderer.receiverModel.renderPart("Receiver");
+        getBeamReceiver().renderPart("Receiver");
         GL11.glEnable(GL11.GL_TEXTURE_2D);
         GL11.glEnable(GL11.GL_CULL_FACE);
 

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererBeamReceiver.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererBeamReceiver.java
@@ -1,5 +1,7 @@
 package micdoodle8.mods.galacticraft.planets.asteroids.client.render.item;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getBeamReceiver;
+
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.IItemRenderer;
 
@@ -8,8 +10,6 @@ import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.client.FMLClientHandler;
 import micdoodle8.mods.galacticraft.planets.asteroids.client.render.tile.TileEntityBeamReceiverRenderer;
-
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getBeamReceiver;
 
 public class ItemRendererBeamReceiver implements IItemRenderer {
 

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererBeamReceiver.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererBeamReceiver.java
@@ -1,17 +1,19 @@
 package micdoodle8.mods.galacticraft.planets.asteroids.client.render.item;
 
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getBeamReceiver;
-
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.IItemRenderer;
+import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.Sys;
 import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.client.FMLClientHandler;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.planets.asteroids.client.render.tile.TileEntityBeamReceiverRenderer;
 
 public class ItemRendererBeamReceiver implements IItemRenderer {
+
+    private final IModelCustom beamReceiver = GalacticraftModels.getBeamReceiver();
 
     private void renderBeamReceiver(ItemRenderType type) {
         GL11.glPushMatrix();
@@ -21,14 +23,14 @@ public class ItemRendererBeamReceiver implements IItemRenderer {
 
         FMLClientHandler.instance().getClient().renderEngine
                 .bindTexture(TileEntityBeamReceiverRenderer.receiverTexture);
-        getBeamReceiver().renderPart("Main");
-        getBeamReceiver().renderPart("Ring");
+        beamReceiver.renderPart("Main");
+        beamReceiver.renderPart("Ring");
 
         GL11.glColor3f(0.6F, 0.3F, 0.0F);
 
         GL11.glDisable(GL11.GL_TEXTURE_2D);
         GL11.glDisable(GL11.GL_CULL_FACE);
-        getBeamReceiver().renderPart("Receiver");
+        beamReceiver.renderPart("Receiver");
         GL11.glEnable(GL11.GL_TEXTURE_2D);
         GL11.glEnable(GL11.GL_CULL_FACE);
 

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererBeamReflector.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererBeamReflector.java
@@ -1,5 +1,7 @@
 package micdoodle8.mods.galacticraft.planets.asteroids.client.render.item;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getBeamReflector;
+
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.IItemRenderer;
 
@@ -8,8 +10,6 @@ import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.client.FMLClientHandler;
 import micdoodle8.mods.galacticraft.planets.asteroids.client.render.tile.TileEntityBeamReflectorRenderer;
-
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getBeamReflector;
 
 public class ItemRendererBeamReflector implements IItemRenderer {
 

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererBeamReflector.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererBeamReflector.java
@@ -1,24 +1,26 @@
 package micdoodle8.mods.galacticraft.planets.asteroids.client.render.item;
 
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getBeamReflector;
-
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.IItemRenderer;
+import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.Sys;
 import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.client.FMLClientHandler;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.planets.asteroids.client.render.tile.TileEntityBeamReflectorRenderer;
 
 public class ItemRendererBeamReflector implements IItemRenderer {
+
+    private final IModelCustom beamReflector = GalacticraftModels.getBeamReflector();
 
     private void renderBeamReflector(ItemRenderType type) {
         GL11.glPushMatrix();
         this.transform(type);
         FMLClientHandler.instance().getClient().renderEngine
                 .bindTexture(TileEntityBeamReflectorRenderer.reflectorTexture);
-        getBeamReflector().renderAll();
+        beamReflector.renderAll();
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererBeamReflector.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererBeamReflector.java
@@ -9,6 +9,8 @@ import org.lwjgl.opengl.GL11;
 import cpw.mods.fml.client.FMLClientHandler;
 import micdoodle8.mods.galacticraft.planets.asteroids.client.render.tile.TileEntityBeamReflectorRenderer;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getBeamReflector;
+
 public class ItemRendererBeamReflector implements IItemRenderer {
 
     private void renderBeamReflector(ItemRenderType type) {
@@ -16,7 +18,7 @@ public class ItemRendererBeamReflector implements IItemRenderer {
         this.transform(type);
         FMLClientHandler.instance().getClient().renderEngine
                 .bindTexture(TileEntityBeamReflectorRenderer.reflectorTexture);
-        TileEntityBeamReflectorRenderer.reflectorModel.renderAll();
+        getBeamReflector().renderAll();
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererShortRangeTelepad.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererShortRangeTelepad.java
@@ -2,13 +2,17 @@ package micdoodle8.mods.galacticraft.planets.asteroids.client.render.item;
 
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.IItemRenderer;
+import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.client.FMLClientHandler;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.planets.asteroids.client.render.tile.TileEntityShortRangeTelepadRenderer;
 
 public class ItemRendererShortRangeTelepad implements IItemRenderer {
+
+    private final IModelCustom telepadModel = GalacticraftModels.getTeleporter();
 
     private void renderBeamReceiver(ItemRenderType type) {
         GL11.glPushMatrix();
@@ -21,22 +25,22 @@ public class ItemRendererShortRangeTelepad implements IItemRenderer {
         FMLClientHandler.instance().getClient().renderEngine
                 .bindTexture(TileEntityShortRangeTelepadRenderer.telepadTexture);
 
-        TileEntityShortRangeTelepadRenderer.telepadModel.renderPart("Base");
-        TileEntityShortRangeTelepadRenderer.telepadModel.renderPart("Top");
+        this.telepadModel.renderPart("Base");
+        this.telepadModel.renderPart("Top");
 
         FMLClientHandler.instance().getClient().renderEngine
                 .bindTexture(TileEntityShortRangeTelepadRenderer.telepadTexture0);
-        TileEntityShortRangeTelepadRenderer.telepadModel.renderPart("TopMidxNegz");
-        TileEntityShortRangeTelepadRenderer.telepadModel.renderPart("TopPosxNegz");
-        TileEntityShortRangeTelepadRenderer.telepadModel.renderPart("TopNegxNegz");
+        this.telepadModel.renderPart("TopMidxNegz");
+        this.telepadModel.renderPart("TopPosxNegz");
+        this.telepadModel.renderPart("TopNegxNegz");
 
-        TileEntityShortRangeTelepadRenderer.telepadModel.renderPart("TopMidxMidz");
-        TileEntityShortRangeTelepadRenderer.telepadModel.renderPart("TopPosxMidz");
-        TileEntityShortRangeTelepadRenderer.telepadModel.renderPart("TopNegxMidz");
+        this.telepadModel.renderPart("TopMidxMidz");
+        this.telepadModel.renderPart("TopPosxMidz");
+        this.telepadModel.renderPart("TopNegxMidz");
 
-        TileEntityShortRangeTelepadRenderer.telepadModel.renderPart("TopMidxPosz");
-        TileEntityShortRangeTelepadRenderer.telepadModel.renderPart("TopPosxPosz");
-        TileEntityShortRangeTelepadRenderer.telepadModel.renderPart("TopNegxPosz");
+        this.telepadModel.renderPart("TopMidxPosz");
+        this.telepadModel.renderPart("TopPosxPosz");
+        this.telepadModel.renderPart("TopNegxPosz");
         GL11.glEnable(GL11.GL_BLEND);
         GL11.glPopMatrix();
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererWalkway.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererWalkway.java
@@ -14,6 +14,8 @@ import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule;
 import micdoodle8.mods.galacticraft.planets.asteroids.blocks.AsteroidBlocks;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getWalkway;
+
 public class ItemRendererWalkway implements IItemRenderer {
 
     private static final ResourceLocation textureMain = new ResourceLocation(
@@ -25,11 +27,9 @@ public class ItemRendererWalkway implements IItemRenderer {
     private static final ResourceLocation texturePipe = new ResourceLocation(
             GalacticraftCore.ASSET_PREFIX,
             "textures/blocks/pipe_oxygen_white.png");
-    public static IModelCustom modelWalkway;
 
     public ItemRendererWalkway() {
-        modelWalkway = AdvancedModelLoader
-                .loadModel(new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "models/walkway.obj"));
+
     }
 
     private void renderWalkway(ItemRenderType type, ItemStack item) {
@@ -39,16 +39,16 @@ public class ItemRendererWalkway implements IItemRenderer {
         GL11.glColor3f(1.0F, 1.0F, 1.0F);
 
         FMLClientHandler.instance().getClient().renderEngine.bindTexture(textureMain);
-        modelWalkway.renderPart("Walkway");
+        getWalkway().renderPart("Walkway");
 
         if (item.getItem() == Item.getItemFromBlock(AsteroidBlocks.blockWalkway)) {
-            modelWalkway.renderPart("WalkwayBase");
+            getWalkway().renderPart("WalkwayBase");
         } else if (item.getItem() == Item.getItemFromBlock(AsteroidBlocks.blockWalkwayWire)) {
             FMLClientHandler.instance().getClient().renderEngine.bindTexture(textureWire);
-            modelWalkway.renderPart("Wire");
+            getWalkway().renderPart("Wire");
         } else if (item.getItem() == Item.getItemFromBlock(AsteroidBlocks.blockWalkwayOxygenPipe)) {
             FMLClientHandler.instance().getClient().renderEngine.bindTexture(texturePipe);
-            modelWalkway.renderPart("Pipe");
+            getWalkway().renderPart("Pipe");
         }
 
         GL11.glPopMatrix();

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererWalkway.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererWalkway.java
@@ -1,16 +1,16 @@
 package micdoodle8.mods.galacticraft.planets.asteroids.client.render.item;
 
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getWalkway;
-
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.IItemRenderer;
+import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.client.FMLClientHandler;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule;
 import micdoodle8.mods.galacticraft.planets.asteroids.blocks.AsteroidBlocks;
 
@@ -25,10 +25,7 @@ public class ItemRendererWalkway implements IItemRenderer {
     private static final ResourceLocation texturePipe = new ResourceLocation(
             GalacticraftCore.ASSET_PREFIX,
             "textures/blocks/pipe_oxygen_white.png");
-
-    public ItemRendererWalkway() {
-
-    }
+    private final IModelCustom walkway = GalacticraftModels.getWalkway();
 
     private void renderWalkway(ItemRenderType type, ItemStack item) {
         GL11.glPushMatrix();
@@ -37,16 +34,16 @@ public class ItemRendererWalkway implements IItemRenderer {
         GL11.glColor3f(1.0F, 1.0F, 1.0F);
 
         FMLClientHandler.instance().getClient().renderEngine.bindTexture(textureMain);
-        getWalkway().renderPart("Walkway");
+        walkway.renderPart("Walkway");
 
         if (item.getItem() == Item.getItemFromBlock(AsteroidBlocks.blockWalkway)) {
-            getWalkway().renderPart("WalkwayBase");
+            walkway.renderPart("WalkwayBase");
         } else if (item.getItem() == Item.getItemFromBlock(AsteroidBlocks.blockWalkwayWire)) {
             FMLClientHandler.instance().getClient().renderEngine.bindTexture(textureWire);
-            getWalkway().renderPart("Wire");
+            walkway.renderPart("Wire");
         } else if (item.getItem() == Item.getItemFromBlock(AsteroidBlocks.blockWalkwayOxygenPipe)) {
             FMLClientHandler.instance().getClient().renderEngine.bindTexture(texturePipe);
-            getWalkway().renderPart("Pipe");
+            walkway.renderPart("Pipe");
         }
 
         GL11.glPopMatrix();

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererWalkway.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererWalkway.java
@@ -1,11 +1,11 @@
 package micdoodle8.mods.galacticraft.planets.asteroids.client.render.item;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getWalkway;
+
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.IItemRenderer;
-import net.minecraftforge.client.model.AdvancedModelLoader;
-import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
 
@@ -13,8 +13,6 @@ import cpw.mods.fml.client.FMLClientHandler;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule;
 import micdoodle8.mods.galacticraft.planets.asteroids.blocks.AsteroidBlocks;
-
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getWalkway;
 
 public class ItemRendererWalkway implements IItemRenderer {
 

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/tile/TileEntityBeamReceiverRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/tile/TileEntityBeamReceiverRenderer.java
@@ -1,10 +1,10 @@
 package micdoodle8.mods.galacticraft.planets.asteroids.client.render.tile;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getBeamReceiver;
+
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.client.model.AdvancedModelLoader;
-import net.minecraftforge.client.model.IModelCustom;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
@@ -16,8 +16,6 @@ import micdoodle8.mods.galacticraft.core.tile.ReceiverMode;
 import micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule;
 import micdoodle8.mods.galacticraft.planets.asteroids.tile.TileEntityBeamReceiver;
 
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getBeamReceiver;
-
 @SideOnly(Side.CLIENT)
 public class TileEntityBeamReceiverRenderer extends TileEntitySpecialRenderer {
 
@@ -26,7 +24,7 @@ public class TileEntityBeamReceiverRenderer extends TileEntitySpecialRenderer {
             "textures/model/beamReceiver.png");
 
     public TileEntityBeamReceiverRenderer() {
-        
+
     }
 
     public void renderModelAt(TileEntityBeamReceiver tileEntity, double d, double d1, double d2, float f) {

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/tile/TileEntityBeamReceiverRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/tile/TileEntityBeamReceiverRenderer.java
@@ -16,17 +16,17 @@ import micdoodle8.mods.galacticraft.core.tile.ReceiverMode;
 import micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule;
 import micdoodle8.mods.galacticraft.planets.asteroids.tile.TileEntityBeamReceiver;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getBeamReceiver;
+
 @SideOnly(Side.CLIENT)
 public class TileEntityBeamReceiverRenderer extends TileEntitySpecialRenderer {
 
     public static final ResourceLocation receiverTexture = new ResourceLocation(
             AsteroidsModule.ASSET_PREFIX,
             "textures/model/beamReceiver.png");
-    public static IModelCustom receiverModel;
 
     public TileEntityBeamReceiverRenderer() {
-        TileEntityBeamReceiverRenderer.receiverModel = AdvancedModelLoader
-                .loadModel(new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "models/receiver.obj"));
+        
     }
 
     public void renderModelAt(TileEntityBeamReceiver tileEntity, double d, double d1, double d2, float f) {
@@ -70,7 +70,7 @@ public class TileEntityBeamReceiverRenderer extends TileEntitySpecialRenderer {
         }
 
         GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-        TileEntityBeamReceiverRenderer.receiverModel.renderPart("Main");
+        getBeamReceiver().renderPart("Main");
 
         if (tileEntity.modeReceive == ReceiverMode.RECEIVE.ordinal()) {
             GL11.glColor3f(0.0F, 0.8F, 0.0F);
@@ -82,7 +82,7 @@ public class TileEntityBeamReceiverRenderer extends TileEntitySpecialRenderer {
 
         GL11.glDisable(GL11.GL_TEXTURE_2D);
         GL11.glDisable(GL11.GL_CULL_FACE);
-        TileEntityBeamReceiverRenderer.receiverModel.renderPart("Receiver");
+        getBeamReceiver().renderPart("Receiver");
         GL11.glEnable(GL11.GL_TEXTURE_2D);
         GL11.glEnable(GL11.GL_CULL_FACE);
         final float dX = 0.34772F;
@@ -94,7 +94,7 @@ public class TileEntityBeamReceiverRenderer extends TileEntitySpecialRenderer {
         }
         GL11.glTranslatef(-dX, -dY, -dZ);
         GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-        TileEntityBeamReceiverRenderer.receiverModel.renderPart("Ring");
+        getBeamReceiver().renderPart("Ring");
 
         GL11.glPopMatrix();
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/tile/TileEntityBeamReceiverRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/tile/TileEntityBeamReceiverRenderer.java
@@ -1,10 +1,9 @@
 package micdoodle8.mods.galacticraft.planets.asteroids.client.render.tile;
 
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getBeamReceiver;
-
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.model.IModelCustom;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
@@ -12,6 +11,7 @@ import org.lwjgl.opengl.GL11;
 import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.core.tile.ReceiverMode;
 import micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule;
 import micdoodle8.mods.galacticraft.planets.asteroids.tile.TileEntityBeamReceiver;
@@ -22,10 +22,7 @@ public class TileEntityBeamReceiverRenderer extends TileEntitySpecialRenderer {
     public static final ResourceLocation receiverTexture = new ResourceLocation(
             AsteroidsModule.ASSET_PREFIX,
             "textures/model/beamReceiver.png");
-
-    public TileEntityBeamReceiverRenderer() {
-
-    }
+    private final IModelCustom beamReceiver = GalacticraftModels.getBeamReceiver();
 
     public void renderModelAt(TileEntityBeamReceiver tileEntity, double d, double d1, double d2, float f) {
         // Texture file
@@ -68,7 +65,7 @@ public class TileEntityBeamReceiverRenderer extends TileEntitySpecialRenderer {
         }
 
         GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-        getBeamReceiver().renderPart("Main");
+        beamReceiver.renderPart("Main");
 
         if (tileEntity.modeReceive == ReceiverMode.RECEIVE.ordinal()) {
             GL11.glColor3f(0.0F, 0.8F, 0.0F);
@@ -80,7 +77,7 @@ public class TileEntityBeamReceiverRenderer extends TileEntitySpecialRenderer {
 
         GL11.glDisable(GL11.GL_TEXTURE_2D);
         GL11.glDisable(GL11.GL_CULL_FACE);
-        getBeamReceiver().renderPart("Receiver");
+        beamReceiver.renderPart("Receiver");
         GL11.glEnable(GL11.GL_TEXTURE_2D);
         GL11.glEnable(GL11.GL_CULL_FACE);
         final float dX = 0.34772F;
@@ -92,7 +89,7 @@ public class TileEntityBeamReceiverRenderer extends TileEntitySpecialRenderer {
         }
         GL11.glTranslatef(-dX, -dY, -dZ);
         GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-        getBeamReceiver().renderPart("Ring");
+        beamReceiver.renderPart("Ring");
 
         GL11.glPopMatrix();
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/tile/TileEntityBeamReflectorRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/tile/TileEntityBeamReflectorRenderer.java
@@ -1,7 +1,5 @@
 package micdoodle8.mods.galacticraft.planets.asteroids.client.render.tile;
 
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getBeamReflector;
-
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
@@ -12,6 +10,7 @@ import org.lwjgl.opengl.GL11;
 import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule;
 import micdoodle8.mods.galacticraft.planets.asteroids.tile.TileEntityBeamReflector;
 
@@ -21,11 +20,7 @@ public class TileEntityBeamReflectorRenderer extends TileEntitySpecialRenderer {
     public static final ResourceLocation reflectorTexture = new ResourceLocation(
             AsteroidsModule.ASSET_PREFIX,
             "textures/model/beamReflector.png");
-    public static IModelCustom reflectorModel;
-
-    public TileEntityBeamReflectorRenderer() {
-
-    }
+    private final IModelCustom beamReflector = GalacticraftModels.getBeamReflector();
 
     public void renderModelAt(TileEntityBeamReflector tileEntity, double d, double d1, double d2, float f) {
         // Texture file
@@ -37,20 +32,20 @@ public class TileEntityBeamReflectorRenderer extends TileEntitySpecialRenderer {
         GL11.glTranslatef((float) d + 0.5F, (float) d1, (float) d2 + 0.5F);
         GL11.glScalef(0.5F, 0.5F, 0.5F);
 
-        getBeamReflector().renderPart("Base");
+        beamReflector.renderPart("Base");
         GL11.glRotatef(tileEntity.yaw, 0, 1, 0);
-        getBeamReflector().renderPart("Axle");
+        beamReflector.renderPart("Axle");
         final float dX = 0.0F;
         final float dY = 1.13228F;
         final float dZ = 0.0F;
         GL11.glTranslatef(dX, dY, dZ);
         GL11.glRotatef(tileEntity.pitch, 1, 0, 0);
         GL11.glTranslatef(-dX, -dY, -dZ);
-        getBeamReflector().renderPart("EnergyBlaster");
+        beamReflector.renderPart("EnergyBlaster");
         GL11.glTranslatef(dX, dY, dZ);
         GL11.glRotatef(tileEntity.ticks * 500, 0, 0, 1);
         GL11.glTranslatef(-dX, -dY, -dZ);
-        getBeamReflector().renderPart("Ring");
+        beamReflector.renderPart("Ring");
 
         GL11.glPopMatrix();
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/tile/TileEntityBeamReflectorRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/tile/TileEntityBeamReflectorRenderer.java
@@ -1,9 +1,10 @@
 package micdoodle8.mods.galacticraft.planets.asteroids.client.render.tile;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getBeamReflector;
+
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.client.model.AdvancedModelLoader;
 import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
@@ -13,8 +14,6 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule;
 import micdoodle8.mods.galacticraft.planets.asteroids.tile.TileEntityBeamReflector;
-
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getBeamReflector;
 
 @SideOnly(Side.CLIENT)
 public class TileEntityBeamReflectorRenderer extends TileEntitySpecialRenderer {

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/tile/TileEntityBeamReflectorRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/tile/TileEntityBeamReflectorRenderer.java
@@ -14,6 +14,8 @@ import cpw.mods.fml.relauncher.SideOnly;
 import micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule;
 import micdoodle8.mods.galacticraft.planets.asteroids.tile.TileEntityBeamReflector;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getBeamReflector;
+
 @SideOnly(Side.CLIENT)
 public class TileEntityBeamReflectorRenderer extends TileEntitySpecialRenderer {
 
@@ -23,8 +25,7 @@ public class TileEntityBeamReflectorRenderer extends TileEntitySpecialRenderer {
     public static IModelCustom reflectorModel;
 
     public TileEntityBeamReflectorRenderer() {
-        TileEntityBeamReflectorRenderer.reflectorModel = AdvancedModelLoader
-                .loadModel(new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "models/reflector.obj"));
+
     }
 
     public void renderModelAt(TileEntityBeamReflector tileEntity, double d, double d1, double d2, float f) {
@@ -37,20 +38,20 @@ public class TileEntityBeamReflectorRenderer extends TileEntitySpecialRenderer {
         GL11.glTranslatef((float) d + 0.5F, (float) d1, (float) d2 + 0.5F);
         GL11.glScalef(0.5F, 0.5F, 0.5F);
 
-        TileEntityBeamReflectorRenderer.reflectorModel.renderPart("Base");
+        getBeamReflector().renderPart("Base");
         GL11.glRotatef(tileEntity.yaw, 0, 1, 0);
-        TileEntityBeamReflectorRenderer.reflectorModel.renderPart("Axle");
+        getBeamReflector().renderPart("Axle");
         final float dX = 0.0F;
         final float dY = 1.13228F;
         final float dZ = 0.0F;
         GL11.glTranslatef(dX, dY, dZ);
         GL11.glRotatef(tileEntity.pitch, 1, 0, 0);
         GL11.glTranslatef(-dX, -dY, -dZ);
-        TileEntityBeamReflectorRenderer.reflectorModel.renderPart("EnergyBlaster");
+        getBeamReflector().renderPart("EnergyBlaster");
         GL11.glTranslatef(dX, dY, dZ);
         GL11.glRotatef(tileEntity.ticks * 500, 0, 0, 1);
         GL11.glTranslatef(-dX, -dY, -dZ);
-        TileEntityBeamReflectorRenderer.reflectorModel.renderPart("Ring");
+        getBeamReflector().renderPart("Ring");
 
         GL11.glPopMatrix();
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/tile/TileEntityMinerBaseRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/tile/TileEntityMinerBaseRenderer.java
@@ -1,7 +1,5 @@
 package micdoodle8.mods.galacticraft.planets.asteroids.client.render.tile;
 
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getTelepad;
-
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
@@ -14,6 +12,7 @@ import org.lwjgl.opengl.GL12;
 import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule;
 import micdoodle8.mods.galacticraft.planets.asteroids.tile.TileEntityMinerBase;
 
@@ -23,11 +22,7 @@ public class TileEntityMinerBaseRenderer extends TileEntitySpecialRenderer {
     public static final ResourceLocation telepadTexture = new ResourceLocation(
             AsteroidsModule.ASSET_PREFIX,
             "textures/model/minerbase.png");
-    public static IModelCustom telepadModel;
-
-    public TileEntityMinerBaseRenderer() {
-
-    }
+    private final IModelCustom telepad = GalacticraftModels.getTelepad();
 
     public void renderModelAt(TileEntityMinerBase tileEntity, double d, double d1, double d2, float f) {
         GL11.glDisable(GL12.GL_RESCALE_NORMAL);
@@ -63,7 +58,7 @@ public class TileEntityMinerBaseRenderer extends TileEntitySpecialRenderer {
                 break;
         }
 
-        getTelepad().renderAll();
+        telepad.renderAll();
 
         GL11.glPopMatrix();
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/tile/TileEntityMinerBaseRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/tile/TileEntityMinerBaseRenderer.java
@@ -16,6 +16,8 @@ import cpw.mods.fml.relauncher.SideOnly;
 import micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule;
 import micdoodle8.mods.galacticraft.planets.asteroids.tile.TileEntityMinerBase;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getTelepad;
+
 @SideOnly(Side.CLIENT)
 public class TileEntityMinerBaseRenderer extends TileEntitySpecialRenderer {
 
@@ -25,8 +27,7 @@ public class TileEntityMinerBaseRenderer extends TileEntitySpecialRenderer {
     public static IModelCustom telepadModel;
 
     public TileEntityMinerBaseRenderer() {
-        TileEntityMinerBaseRenderer.telepadModel = AdvancedModelLoader
-                .loadModel(new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "models/minerbase.obj"));
+
     }
 
     public void renderModelAt(TileEntityMinerBase tileEntity, double d, double d1, double d2, float f) {
@@ -63,7 +64,7 @@ public class TileEntityMinerBaseRenderer extends TileEntitySpecialRenderer {
                 break;
         }
 
-        TileEntityMinerBaseRenderer.telepadModel.renderAll();
+        getTelepad().renderAll();
 
         GL11.glPopMatrix();
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/tile/TileEntityMinerBaseRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/tile/TileEntityMinerBaseRenderer.java
@@ -1,10 +1,11 @@
 package micdoodle8.mods.galacticraft.planets.asteroids.client.render.tile;
 
+import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getTelepad;
+
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.client.model.AdvancedModelLoader;
 import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
@@ -15,8 +16,6 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule;
 import micdoodle8.mods.galacticraft.planets.asteroids.tile.TileEntityMinerBase;
-
-import static micdoodle8.mods.galacticraft.core.client.GalacticraftModels.getTelepad;
 
 @SideOnly(Side.CLIENT)
 public class TileEntityMinerBaseRenderer extends TileEntitySpecialRenderer {

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/tile/TileEntityShortRangeTelepadRenderer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/tile/TileEntityShortRangeTelepadRenderer.java
@@ -3,7 +3,6 @@ package micdoodle8.mods.galacticraft.planets.asteroids.client.render.tile;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.client.model.AdvancedModelLoader;
 import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
@@ -11,6 +10,7 @@ import org.lwjgl.opengl.GL11;
 import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.planets.asteroids.AsteroidsModule;
 import micdoodle8.mods.galacticraft.planets.asteroids.tile.TileEntityShortRangeTelepad;
 
@@ -23,12 +23,7 @@ public class TileEntityShortRangeTelepadRenderer extends TileEntitySpecialRender
     public static final ResourceLocation telepadTexture0 = new ResourceLocation(
             AsteroidsModule.ASSET_PREFIX,
             "textures/model/teleporter0.png");
-    public static IModelCustom telepadModel;
-
-    public TileEntityShortRangeTelepadRenderer() {
-        TileEntityShortRangeTelepadRenderer.telepadModel = AdvancedModelLoader
-                .loadModel(new ResourceLocation(AsteroidsModule.ASSET_PREFIX, "models/teleporter.obj"));
-    }
+    private final IModelCustom telepadModel = GalacticraftModels.getTeleporter();
 
     public void renderModelAt(TileEntityShortRangeTelepad tileEntity, double d, double d1, double d2, float f) {
         // Texture file
@@ -39,9 +34,9 @@ public class TileEntityShortRangeTelepadRenderer extends TileEntitySpecialRender
 
         GL11.glTranslatef((float) d + 0.5F, (float) d1, (float) d2 + 0.5F);
         GL11.glScalef(1F, 0.65F, 1F);
-        TileEntityShortRangeTelepadRenderer.telepadModel.renderPart("Base");
+        this.telepadModel.renderPart("Base");
         GL11.glTranslatef(0.0F, (float) Math.sin(tileEntity.ticks / 10.0F) / 15.0F - 0.25F, 0.0F);
-        TileEntityShortRangeTelepadRenderer.telepadModel.renderPart("Top");
+        this.telepadModel.renderPart("Top");
 
         GL11.glPopMatrix();
 
@@ -51,17 +46,17 @@ public class TileEntityShortRangeTelepadRenderer extends TileEntitySpecialRender
         GL11.glScalef(1F, 0.65F, 1F);
         FMLClientHandler.instance().getClient().renderEngine
                 .bindTexture(TileEntityShortRangeTelepadRenderer.telepadTexture0);
-        TileEntityShortRangeTelepadRenderer.telepadModel.renderPart("TopMidxNegz");
-        TileEntityShortRangeTelepadRenderer.telepadModel.renderPart("TopPosxNegz");
-        TileEntityShortRangeTelepadRenderer.telepadModel.renderPart("TopNegxNegz");
+        this.telepadModel.renderPart("TopMidxNegz");
+        this.telepadModel.renderPart("TopPosxNegz");
+        this.telepadModel.renderPart("TopNegxNegz");
 
-        TileEntityShortRangeTelepadRenderer.telepadModel.renderPart("TopMidxMidz");
-        TileEntityShortRangeTelepadRenderer.telepadModel.renderPart("TopPosxMidz");
-        TileEntityShortRangeTelepadRenderer.telepadModel.renderPart("TopNegxMidz");
+        this.telepadModel.renderPart("TopMidxMidz");
+        this.telepadModel.renderPart("TopPosxMidz");
+        this.telepadModel.renderPart("TopNegxMidz");
 
-        TileEntityShortRangeTelepadRenderer.telepadModel.renderPart("TopMidxPosz");
-        TileEntityShortRangeTelepadRenderer.telepadModel.renderPart("TopPosxPosz");
-        TileEntityShortRangeTelepadRenderer.telepadModel.renderPart("TopNegxPosz");
+        this.telepadModel.renderPart("TopMidxPosz");
+        this.telepadModel.renderPart("TopPosxPosz");
+        this.telepadModel.renderPart("TopNegxPosz");
 
         GL11.glPopMatrix();
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/MarsModuleClient.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/MarsModuleClient.java
@@ -14,7 +14,6 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.client.MinecraftForgeClient;
-import net.minecraftforge.client.model.AdvancedModelLoader;
 import net.minecraftforge.client.model.IModelCustom;
 
 import cpw.mods.fml.client.FMLClientHandler;
@@ -31,6 +30,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 import micdoodle8.mods.galacticraft.api.vector.Vector3;
 import micdoodle8.mods.galacticraft.api.world.IGalacticraftWorldProvider;
 import micdoodle8.mods.galacticraft.core.client.CloudRenderer;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.core.client.render.entities.RenderTier1Rocket;
 import micdoodle8.mods.galacticraft.core.client.render.item.ItemRendererKey;
 import micdoodle8.mods.galacticraft.core.client.render.tile.TileEntityBubbleProviderRenderer;
@@ -108,8 +108,8 @@ public class MarsModuleClient implements IPlanetsModuleClient {
     @Override
     public void postInit(FMLPostInitializationEvent event) {
         // spotless:off
-        final IModelCustom chamberModel = AdvancedModelLoader.loadModel(new ResourceLocation(MarsModule.ASSET_PREFIX, "models/chamber.obj"));
-        final IModelCustom cargoRocketModel = AdvancedModelLoader.loadModel(new ResourceLocation(MarsModule.ASSET_PREFIX, "models/cargoRocket.obj"));
+        final IModelCustom chamberModel = GalacticraftModels.getChamber();
+        final IModelCustom cargoRocketModel = GalacticraftModels.getCargoRocket();
 
         // Tile Entity Renderers
         ClientRegistry.bindTileEntitySpecialRenderer(TileEntityTreasureChestMars.class, new TileEntityTreasureChestRenderer());

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/MarsModuleClient.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/MarsModuleClient.java
@@ -107,48 +107,36 @@ public class MarsModuleClient implements IPlanetsModuleClient {
 
     @Override
     public void postInit(FMLPostInitializationEvent event) {
-        final IModelCustom chamberModel = AdvancedModelLoader
-                .loadModel(new ResourceLocation(MarsModule.ASSET_PREFIX, "models/chamber.obj"));
-        final IModelCustom cargoRocketModel = AdvancedModelLoader
-                .loadModel(new ResourceLocation(MarsModule.ASSET_PREFIX, "models/cargoRocket.obj"));
+        // spotless:off
+        final IModelCustom chamberModel = AdvancedModelLoader.loadModel(new ResourceLocation(MarsModule.ASSET_PREFIX, "models/chamber.obj"));
+        final IModelCustom cargoRocketModel = AdvancedModelLoader.loadModel(new ResourceLocation(MarsModule.ASSET_PREFIX, "models/cargoRocket.obj"));
 
         // Tile Entity Renderers
-        ClientRegistry.bindTileEntitySpecialRenderer(
-                TileEntityTreasureChestMars.class,
-                new TileEntityTreasureChestRenderer());
-        ClientRegistry.bindTileEntitySpecialRenderer(
-                TileEntityCryogenicChamber.class,
-                new TileEntityCryogenicChamberRenderer(chamberModel));
-        ClientRegistry.bindTileEntitySpecialRenderer(
-                TileEntityTerraformer.class,
-                new TileEntityBubbleProviderRenderer(0.25F, 1.0F, 0.25F));
+        ClientRegistry.bindTileEntitySpecialRenderer(TileEntityTreasureChestMars.class, new TileEntityTreasureChestRenderer());
+        ClientRegistry.bindTileEntitySpecialRenderer(TileEntityCryogenicChamber.class, new TileEntityCryogenicChamberRenderer(chamberModel));
+        ClientRegistry.bindTileEntitySpecialRenderer(TileEntityTerraformer.class, new TileEntityBubbleProviderRenderer(0.25F, 1.0F, 0.25F));
 
         // Entities
         RenderingRegistry.registerEntityRenderingHandler(EntitySludgeling.class, new RenderSludgeling());
         RenderingRegistry.registerEntityRenderingHandler(EntitySlimeling.class, new RenderSlimeling());
         RenderingRegistry.registerEntityRenderingHandler(EntityCreeperBoss.class, new RenderCreeperBoss());
-        RenderingRegistry.registerEntityRenderingHandler(
-                EntityTier2Rocket.class,
-                new RenderTier1Rocket(new ModelTier2Rocket(), MarsModule.ASSET_PREFIX, "rocketT2"));
+        RenderingRegistry.registerEntityRenderingHandler(EntityTier2Rocket.class, new RenderTier1Rocket(new ModelTier2Rocket(), MarsModule.ASSET_PREFIX, "rocketT2"));
         // RenderingRegistry.registerEntityRenderingHandler(EntityTerraformBubble.class,
         // new RenderBubble(0.25F,
         // 1.0F, 0.25F));
         RenderingRegistry.registerEntityRenderingHandler(EntityProjectileTNT.class, new RenderProjectileTNT());
         RenderingRegistry.registerEntityRenderingHandler(EntityLandingBalloons.class, new RenderLandingBalloons());
         RenderingRegistry.registerEntityRenderingHandler(EntityLandingBalloons.class, new RenderLandingBalloons());
-        RenderingRegistry
-                .registerEntityRenderingHandler(EntityCargoRocket.class, new RenderCargoRocket(cargoRocketModel));
+        RenderingRegistry.registerEntityRenderingHandler(EntityCargoRocket.class, new RenderCargoRocket(cargoRocketModel));
 
         // Add Armor Renderer Prefix
         RenderingRegistry.addNewArmourRendererPrefix("desh");
 
         // Item Renderers
         MinecraftForgeClient.registerItemRenderer(MarsItems.spaceship, new ItemRendererTier2Rocket(cargoRocketModel));
-        MinecraftForgeClient.registerItemRenderer(
-                MarsItems.key,
-                new ItemRendererKey(new ResourceLocation(MarsModule.ASSET_PREFIX, "textures/model/treasure.png")));
-        MinecraftForgeClient
-                .registerItemRenderer(Item.getItemFromBlock(MarsBlocks.machine), new ItemRendererMachine(chamberModel));
+        MinecraftForgeClient.registerItemRenderer(MarsItems.key, new ItemRendererKey(new ResourceLocation(MarsModule.ASSET_PREFIX, "textures/model/treasure.png")));
+        MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(MarsBlocks.machine), new ItemRendererMachine(chamberModel));
+        // spotless:on
     }
 
     @Override

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/MarsModuleClient.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/MarsModuleClient.java
@@ -126,7 +126,6 @@ public class MarsModuleClient implements IPlanetsModuleClient {
         // 1.0F, 0.25F));
         RenderingRegistry.registerEntityRenderingHandler(EntityProjectileTNT.class, new RenderProjectileTNT());
         RenderingRegistry.registerEntityRenderingHandler(EntityLandingBalloons.class, new RenderLandingBalloons());
-        RenderingRegistry.registerEntityRenderingHandler(EntityLandingBalloons.class, new RenderLandingBalloons());
         RenderingRegistry.registerEntityRenderingHandler(EntityCargoRocket.class, new RenderCargoRocket(cargoRocketModel));
 
         // Add Armor Renderer Prefix

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/client/render/entity/RenderLandingBalloons.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/client/render/entity/RenderLandingBalloons.java
@@ -3,13 +3,13 @@ package micdoodle8.mods.galacticraft.planets.mars.client.render.entity;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.client.model.AdvancedModelLoader;
 import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import micdoodle8.mods.galacticraft.core.client.GalacticraftModels;
 import micdoodle8.mods.galacticraft.planets.mars.MarsModule;
 import micdoodle8.mods.galacticraft.planets.mars.client.model.ModelBalloonParachute;
 import micdoodle8.mods.galacticraft.planets.mars.entities.EntityLandingBalloons;
@@ -26,8 +26,7 @@ public class RenderLandingBalloons extends Render {
 
     public RenderLandingBalloons() {
         this.shadowSize = 1.2F;
-        this.landerModel = AdvancedModelLoader
-                .loadModel(new ResourceLocation(MarsModule.ASSET_PREFIX, "models/landingBalloon.obj"));
+        this.landerModel = GalacticraftModels.getLandingBalloon();
     }
 
     protected ResourceLocation func_110779_a(EntityLandingBalloons par1EntityArrow) {


### PR DESCRIPTION
Loading a models costs place in memory and loading the same model twice is stupid. I made a class that loads the models once and gives reference to the loaded models. I did not change all the model registration to use the new class cause I got lazy and there's too many

