### PR TITLE
[Memory-opti:fix leak] Fix world client leak in ItemRendererFlag

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/item/ItemRendererFlag.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/item/ItemRendererFlag.java
@@ -16,7 +16,7 @@ import micdoodle8.mods.galacticraft.core.util.ClientUtil;
 
 public class ItemRendererFlag implements IItemRenderer {
 
-    private final EntityFlag entityFlagDummy = new EntityFlag(FMLClientHandler.instance().getClient().theWorld);
+    private final EntityFlag entityFlagDummy = new EntityFlag(null);
     private final ModelFlag modelFlag = new ModelFlag();
 
     private void renderFlag(ItemRenderType type, ItemStack item, Object... data) {
@@ -27,7 +27,6 @@ public class ItemRendererFlag implements IItemRenderer {
         final float var13 = (((var10 >> 20 & 7L) + 0.5F) / 8.0F - 0.5F) * 0.004F;
         final float var14 = (((var10 >> 24 & 7L) + 0.5F) / 8.0F - 0.5F) * 0.004F;
 
-        this.entityFlagDummy.worldObj = FMLClientHandler.instance().getClient().theWorld;
         this.entityFlagDummy.ticksExisted = (int) FMLClientHandler.instance().getWorldClient().getTotalWorldTime();
         this.entityFlagDummy.setType(item.getItemDamage());
 
@@ -101,7 +100,12 @@ public class ItemRendererFlag implements IItemRenderer {
 
         FMLClientHandler.instance().getClient().renderEngine.bindTexture(RenderFlag.flagTexture);
 
-        this.modelFlag.render(this.entityFlagDummy, 0.0F, 0.0F, -0.1F, 0.0F, 0.0F, 0.0625F);
+        try {
+            this.entityFlagDummy.worldObj = FMLClientHandler.instance().getClient().theWorld;
+            this.modelFlag.render(this.entityFlagDummy, 0.0F, 0.0F, -0.1F, 0.0F, 0.0F, 0.0625F);
+        } finally {
+            this.entityFlagDummy.worldObj = null;
+        }
         GL11.glPopMatrix();
     }
 
@@ -111,10 +115,7 @@ public class ItemRendererFlag implements IItemRenderer {
     @Override
     public boolean handleRenderType(ItemStack item, ItemRenderType type) {
         return switch (type) {
-            case ENTITY -> true;
-            case EQUIPPED -> true;
-            case EQUIPPED_FIRST_PERSON -> true;
-            case INVENTORY -> true;
+            case ENTITY, EQUIPPED, EQUIPPED_FIRST_PERSON, INVENTORY -> true;
             default -> false;
         };
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/client/render/item/ItemRendererTier1Rocket.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/client/render/item/ItemRendererTier1Rocket.java
@@ -3,7 +3,6 @@ package micdoodle8.mods.galacticraft.core.client.render.item;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelChest;
 import net.minecraft.client.renderer.RenderBlocks;
-import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -21,13 +20,10 @@ public class ItemRendererTier1Rocket implements IItemRenderer {
 
     protected static final ResourceLocation chestTexture = new ResourceLocation("textures/entity/chest/normal.png");
 
-    protected EntitySpaceshipBase spaceship;
-    protected ModelBase modelSpaceship;
+    protected final EntitySpaceshipBase spaceship;
+    protected final ModelBase modelSpaceship;
     protected final ModelChest chestModel = new ModelChest();
-
-    protected static RenderItem drawItems = new RenderItem();
-
-    protected ResourceLocation texture;
+    protected final ResourceLocation texture;
 
     public ItemRendererTier1Rocket(EntitySpaceshipBase spaceship, ModelBase model, ResourceLocation texture) {
         this.spaceship = spaceship;

--- a/src/main/java/micdoodle8/mods/galacticraft/core/entities/EntityFlag.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/entities/EntityFlag.java
@@ -171,10 +171,10 @@ public class EntityFlag extends Entity {
         final Block blockAt = vec.getBlock(this.worldObj);
 
         if (blockAt != null) {
-            if (blockAt instanceof BlockFence) {
-
-            } else if (blockAt.isAir(this.worldObj, vec.intX(), vec.intY(), vec.intZ())) {
-                this.motionY -= 0.02F;
+            if (!(blockAt instanceof BlockFence)) {
+                if (blockAt.isAir(this.worldObj, vec.intX(), vec.intY(), vec.intZ())) {
+                    this.motionY -= 0.02F;
+                }
             }
         }
 
@@ -199,7 +199,7 @@ public class EntityFlag extends Entity {
     }
 
     public void setDamage(float par1) {
-        this.dataWatcher.updateObject(18, Float.valueOf(par1));
+        this.dataWatcher.updateObject(18, par1);
     }
 
     public float getDamage() {
@@ -207,7 +207,7 @@ public class EntityFlag extends Entity {
     }
 
     public void setType(int par1) {
-        this.dataWatcher.updateObject(19, Integer.valueOf(par1));
+        this.dataWatcher.updateObject(19, par1);
     }
 
     public int getType() {
@@ -215,7 +215,7 @@ public class EntityFlag extends Entity {
     }
 
     public void setFacingAngle(int par1) {
-        this.dataWatcher.updateObject(20, Integer.valueOf(par1));
+        this.dataWatcher.updateObject(20, par1);
     }
 
     public int getFacingAngle() {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/proxy/ClientProxyCore.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/proxy/ClientProxyCore.java
@@ -323,7 +323,7 @@ public class ClientProxyCore extends CommonProxyCore {
     public static void registerItemRenderers() {
         // spotless:off
         MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(GCBlocks.unlitTorch), new ItemRendererUnlitTorch());
-        MinecraftForgeClient.registerItemRenderer(GCItems.rocketTier1, new ItemRendererTier1Rocket(new EntityTier1Rocket(ClientProxyCore.mc.theWorld), new ModelRocketTier1(), new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "textures/model/rocketT1.png")));
+        MinecraftForgeClient.registerItemRenderer(GCItems.rocketTier1, new ItemRendererTier1Rocket(new EntityTier1Rocket(null), new ModelRocketTier1(), new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "textures/model/rocketT1.png")));
         MinecraftForgeClient.registerItemRenderer(GCItems.buggy, new ItemRendererBuggy());
         MinecraftForgeClient.registerItemRenderer(GCItems.flag, new ItemRendererFlag());
         MinecraftForgeClient.registerItemRenderer(GCItems.key, new ItemRendererKey(new ResourceLocation(GalacticraftCore.ASSET_PREFIX, "textures/model/treasure.png")));

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/client/render/item/ItemRendererTier2Rocket.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/client/render/item/ItemRendererTier2Rocket.java
@@ -27,7 +27,7 @@ public class ItemRendererTier2Rocket extends ItemRendererTier1Rocket {
 
     public ItemRendererTier2Rocket(IModelCustom cargoRocketModel) {
         super(
-                new EntityTier2Rocket(FMLClientHandler.instance().getClient().theWorld),
+                new EntityTier2Rocket(null),
                 new ModelTier2Rocket(),
                 new ResourceLocation(MarsModule.ASSET_PREFIX, "textures/model/rocketT2.png"));
         this.cargoRocketModel = cargoRocketModel;


### PR DESCRIPTION
<img width="597" height="143" alt="image" src="https://github.com/user-attachments/assets/fb64749b-441b-4c17-b03d-b6430dbc76d6" />
