### PR TITLE
Fix EID Space Station Travel Crash

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/world/gen/ChunkProviderOrbit.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/world/gen/ChunkProviderOrbit.java
@@ -62,9 +62,7 @@ public class ChunkProviderOrbit extends ChunkProviderGenerate {
         final Chunk var4 = new Chunk(this.worldObj, ids, meta, par1, par2);
 
         final byte[] biomesArray = var4.getBiomeArray();
-        for (int i = 0; i < biomesArray.length; ++i) {
-            biomesArray[i] = (byte) BiomeGenBaseOrbit.space.biomeID;
-        }
+        Arrays.fill(biomesArray, (byte) BiomeGenBaseOrbit.space.biomeID);
 
         var4.generateSkylightMap();
         return var4;


### PR DESCRIPTION
EID yet again having another incompatibility with a chunk provider, but Galacticraft edition.

Tested https://discord.com/channels/181078474394566657/522098956491030558/1503914980230168646