### PR TITLE
Strip out 1.7.2 compatibility code

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/blocks/BlockBrightLamp.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/blocks/BlockBrightLamp.java
@@ -19,7 +19,7 @@ import micdoodle8.mods.galacticraft.core.items.ItemBlockDesc;
 import micdoodle8.mods.galacticraft.core.tile.TileEntityArclamp;
 import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
 import micdoodle8.mods.galacticraft.core.util.RedstoneUtil;
-import micdoodle8.mods.galacticraft.core.util.VersionUtil;
+import micdoodle8.mods.galacticraft.core.util.WorldUtil;
 
 public class BlockBrightLamp extends BlockAdvanced implements ItemBlockDesc.IBlockShiftDesc {
 
@@ -43,7 +43,7 @@ public class BlockBrightLamp extends BlockAdvanced implements ItemBlockDesc.IBlo
         if (block != this) {
             return block.getLightValue(world, x, y, z);
         }
-        final World w = VersionUtil.getWorld(world);
+        final World w = WorldUtil.getWorldFromIBlockAccess(world);
         return RedstoneUtil.isBlockReceivingRedstone(w, x, y, z) ? 0 : this.getLightValue();
     }
 

--- a/src/main/java/micdoodle8/mods/galacticraft/core/energy/tile/TileBaseUniversalElectricalSource.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/energy/tile/TileBaseUniversalElectricalSource.java
@@ -117,11 +117,21 @@ public class TileBaseUniversalElectricalSource extends TileBaseUniversalElectric
                 try {
                     if (item instanceof ISpecialElectricItem) {
                         // result: Converted from reflection to plain old casts and calls
-                        double result = ((ISpecialElectricItem)item).getManager(itemStack).charge(itemStack, (double)(energyToCharge * EnergyConfigHandler.TO_IC2_RATIO), this.tierGC + 1, false, false);
+                        double result = ((ISpecialElectricItem) item).getManager(itemStack).charge(
+                                itemStack,
+                                (double) (energyToCharge * EnergyConfigHandler.TO_IC2_RATIO),
+                                this.tierGC + 1,
+                                false,
+                                false);
                         final float energy = (float) result / EnergyConfigHandler.TO_IC2_RATIO;
                         this.storage.extractEnergyGC(energy, false);
                     } else if (item instanceof IElectricItem) {
-                        double result = ElectricItem.manager.charge(itemStack, (double)(energyToCharge * EnergyConfigHandler.TO_IC2_RATIO), this.tierGC + 1, false, false);
+                        double result = ElectricItem.manager.charge(
+                                itemStack,
+                                (double) (energyToCharge * EnergyConfigHandler.TO_IC2_RATIO),
+                                this.tierGC + 1,
+                                false,
+                                false);
                         final float energy = (float) result / EnergyConfigHandler.TO_IC2_RATIO;
                         this.storage.extractEnergyGC(energy, false);
                     }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/energy/tile/TileBaseUniversalElectricalSource.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/energy/tile/TileBaseUniversalElectricalSource.java
@@ -1,6 +1,5 @@
 package micdoodle8.mods.galacticraft.core.energy.tile;
 
-import java.lang.reflect.Method;
 import java.util.EnumSet;
 
 import net.minecraft.item.Item;
@@ -13,6 +12,9 @@ import cofh.api.energy.IEnergyContainerItem;
 import cpw.mods.fml.common.Optional.Interface;
 import cpw.mods.fml.common.Optional.InterfaceList;
 import ic2.api.energy.tile.IEnergySource;
+import ic2.api.item.ElectricItem;
+import ic2.api.item.IElectricItem;
+import ic2.api.item.ISpecialElectricItem;
 import mekanism.api.energy.ICableOutputter;
 import micdoodle8.mods.galacticraft.api.item.ElectricItemHelper;
 import micdoodle8.mods.galacticraft.api.item.IItemElectric;
@@ -22,7 +24,6 @@ import micdoodle8.mods.galacticraft.api.transmission.tile.IElectrical;
 import micdoodle8.mods.galacticraft.api.vector.BlockVec3;
 import micdoodle8.mods.galacticraft.core.energy.EnergyConfigHandler;
 import micdoodle8.mods.galacticraft.core.energy.EnergyUtil;
-import micdoodle8.mods.galacticraft.core.util.VersionUtil;
 
 @InterfaceList({ @Interface(modid = "IC2API", iface = "ic2.api.energy.tile.IEnergySource"),
         @Interface(modid = "MekanismAPI|energy", iface = "mekanism.api.energy.ICableOutputter"), })
@@ -114,87 +115,13 @@ public class TileBaseUniversalElectricalSource extends TileBaseUniversalElectric
                         false);
             } else if (EnergyConfigHandler.isIndustrialCraft2Loaded()) {
                 try {
-                    final Class<?> itemElectricIC2 = Class.forName("ic2.api.item.ISpecialElectricItem");
-                    final Class<?> itemElectricIC2B = Class.forName("ic2.api.item.IElectricItem");
-                    final Class<?> itemManagerIC2 = Class.forName("ic2.api.item.IElectricItemManager");
-                    if (itemElectricIC2.isInstance(item)) {
-                        // Implement by reflection:
-                        // float energy = (float)
-                        // ((ISpecialElectricItem)item).getManager(itemStack).charge(itemStack,
-                        // energyToCharge * EnergyConfigHandler.TO_IC2_RATIO, 4, false, false) *
-                        // EnergyConfigHandler.IC2_RATIO;
-                        final Object IC2item = itemElectricIC2.cast(item);
-                        final Method getMan = itemElectricIC2.getMethod("getManager", ItemStack.class);
-                        final Object IC2manager = getMan.invoke(IC2item, itemStack);
-                        double result;
-                        if (VersionUtil.mcVersion1_7_2) {
-                            final Method methodCharge = itemManagerIC2.getMethod(
-                                    "charge",
-                                    ItemStack.class,
-                                    int.class,
-                                    int.class,
-                                    boolean.class,
-                                    boolean.class);
-                            result = (Integer) methodCharge.invoke(
-                                    IC2manager,
-                                    itemStack,
-                                    (int) (energyToCharge * EnergyConfigHandler.TO_IC2_RATIO),
-                                    this.tierGC + 1,
-                                    false,
-                                    false);
-                        } else {
-                            final Method methodCharge = itemManagerIC2.getMethod(
-                                    "charge",
-                                    ItemStack.class,
-                                    double.class,
-                                    int.class,
-                                    boolean.class,
-                                    boolean.class);
-                            result = (Double) methodCharge.invoke(
-                                    IC2manager,
-                                    itemStack,
-                                    (double) (energyToCharge * EnergyConfigHandler.TO_IC2_RATIO),
-                                    this.tierGC + 1,
-                                    false,
-                                    false);
-                        }
+                    if (item instanceof ISpecialElectricItem) {
+                        // result: Converted from reflection to plain old casts and calls
+                        double result = ((ISpecialElectricItem)item).getManager(itemStack).charge(itemStack, (double)(energyToCharge * EnergyConfigHandler.TO_IC2_RATIO), this.tierGC + 1, false, false);
                         final float energy = (float) result / EnergyConfigHandler.TO_IC2_RATIO;
                         this.storage.extractEnergyGC(energy, false);
-                    } else if (itemElectricIC2B.isInstance(item)) {
-                        final Class<?> electricItemIC2 = Class.forName("ic2.api.item.ElectricItem");
-                        final Object IC2manager = electricItemIC2.getField("manager").get(null);
-                        double result;
-                        if (VersionUtil.mcVersion1_7_2) {
-                            final Method methodCharge = itemManagerIC2.getMethod(
-                                    "charge",
-                                    ItemStack.class,
-                                    int.class,
-                                    int.class,
-                                    boolean.class,
-                                    boolean.class);
-                            result = (Integer) methodCharge.invoke(
-                                    IC2manager,
-                                    itemStack,
-                                    (int) (energyToCharge * EnergyConfigHandler.TO_IC2_RATIO),
-                                    this.tierGC + 1,
-                                    false,
-                                    false);
-                        } else {
-                            final Method methodCharge = itemManagerIC2.getMethod(
-                                    "charge",
-                                    ItemStack.class,
-                                    double.class,
-                                    int.class,
-                                    boolean.class,
-                                    boolean.class);
-                            result = (Double) methodCharge.invoke(
-                                    IC2manager,
-                                    itemStack,
-                                    (double) (energyToCharge * EnergyConfigHandler.TO_IC2_RATIO),
-                                    this.tierGC + 1,
-                                    false,
-                                    false);
-                        }
+                    } else if (item instanceof IElectricItem) {
+                        double result = ElectricItem.manager.charge(itemStack, (double)(energyToCharge * EnergyConfigHandler.TO_IC2_RATIO), this.tierGC + 1, false, false);
                         final float energy = (float) result / EnergyConfigHandler.TO_IC2_RATIO;
                         this.storage.extractEnergyGC(energy, false);
                     }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/entities/EntityEvolvedCreeper.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/entities/EntityEvolvedCreeper.java
@@ -30,7 +30,6 @@ import net.minecraftforge.common.ForgeHooks;
 import micdoodle8.mods.galacticraft.api.entity.IEntityBreathable;
 import micdoodle8.mods.galacticraft.core.items.GCItems;
 import micdoodle8.mods.galacticraft.core.util.ConfigManagerCore;
-import micdoodle8.mods.galacticraft.core.util.VersionUtil;
 import micdoodle8.mods.galacticraft.core.util.WorldUtil;
 
 public class EntityEvolvedCreeper extends EntityCreeper implements IEntityBreathable {
@@ -181,7 +180,7 @@ public class EntityEvolvedCreeper extends EntityCreeper implements IEntityBreath
             case 1:
             case 2:
             case 3:
-                this.entityDropItem(new ItemStack(VersionUtil.sand), 0.0F);
+                this.entityDropItem(new ItemStack(Blocks.sand), 0.0F);
                 break;
             case 4:
             case 5:

--- a/src/main/java/micdoodle8/mods/galacticraft/core/entities/player/GCPlayerHandler.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/entities/player/GCPlayerHandler.java
@@ -1,7 +1,6 @@
 package micdoodle8.mods.galacticraft.core.entities.player;
 
 import java.lang.ref.WeakReference;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -79,7 +78,6 @@ import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
 import micdoodle8.mods.galacticraft.core.util.GCLog;
 import micdoodle8.mods.galacticraft.core.util.OxygenUtil;
 import micdoodle8.mods.galacticraft.core.util.PlayerUtil;
-import micdoodle8.mods.galacticraft.core.util.VersionUtil;
 import micdoodle8.mods.galacticraft.core.util.WorldUtil;
 import micdoodle8.mods.galacticraft.core.wrappers.Footprint;
 import micdoodle8.mods.galacticraft.planets.asteroids.dimension.WorldProviderAsteroids;
@@ -89,7 +87,6 @@ public class GCPlayerHandler {
     private static final int OXYGENHEIGHTLIMIT = 450;
     private final boolean isClient = FMLCommonHandler.instance().getEffectiveSide().isClient();
     private final ConcurrentHashMap<UUID, GCPlayerStats> playerStatsMap = new ConcurrentHashMap<>();
-    private Field ftc;
     private final HashMap<Item, Item> torchItems = new HashMap<>();
 
     public ConcurrentHashMap<UUID, GCPlayerStats> getServerStatList() {
@@ -1420,13 +1417,6 @@ public class GCPlayerHandler {
 
     public void preventFlyingKicks(EntityPlayerMP player) {
         player.fallDistance = 0.0F;
-        try {
-            if (this.ftc == null) {
-                this.ftc = player.playerNetServerHandler.getClass()
-                        .getDeclaredField(VersionUtil.getNameDynamic(VersionUtil.KEY_FIELD_FLOATINGTICKCOUNT));
-                this.ftc.setAccessible(true);
-            }
-            this.ftc.setInt(player.playerNetServerHandler, 0);
-        } catch (final Exception e) {}
+        player.playerNetServerHandler.floatingTickCount = 0;
     }
 }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/mixins/Mixins.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/mixins/Mixins.java
@@ -47,7 +47,9 @@ public enum Mixins implements IMixins {
     MODIFY_RAIN_STRENGTH(new MixinBuilder()
             .addCommonMixins("minecraft.WorldMixin")),
     DONOR_CAPES(new MixinBuilder()
-            .addClientMixins("minecraft.AbstractClientPlayerMixin"));
+            .addClientMixins("minecraft.AbstractClientPlayerMixin")),
+    ACCESS_BLOCK_MEMBERS(new MixinBuilder()
+            .addCommonMixins("minecraft.BlockAccessor"));
     // spotless:on
 
     private final MixinBuilder builder;

--- a/src/main/java/micdoodle8/mods/galacticraft/core/mixins/early/minecraft/BlockAccessor.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/mixins/early/minecraft/BlockAccessor.java
@@ -1,0 +1,13 @@
+package micdoodle8.mods.galacticraft.core.mixins.early.minecraft;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemStack;
+
+@Mixin(Block.class)
+public interface BlockAccessor {
+	@Invoker
+	ItemStack invokeCreateStackedBlock(int meta);
+}

--- a/src/main/java/micdoodle8/mods/galacticraft/core/mixins/early/minecraft/BlockAccessor.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/mixins/early/minecraft/BlockAccessor.java
@@ -1,13 +1,14 @@
 package micdoodle8.mods.galacticraft.core.mixins.early.minecraft;
 
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.gen.Invoker;
-
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
 @Mixin(Block.class)
 public interface BlockAccessor {
-	@Invoker
-	ItemStack invokeCreateStackedBlock(int meta);
+
+    @Invoker
+    ItemStack invokeCreateStackedBlock(int meta);
 }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/network/NetworkUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/network/NetworkUtil.java
@@ -10,6 +10,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTSizeTracker;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.Fluid;
@@ -26,7 +27,6 @@ import micdoodle8.mods.galacticraft.api.vector.Vector3;
 import micdoodle8.mods.galacticraft.core.energy.tile.EnergyStorage;
 import micdoodle8.mods.galacticraft.core.util.FluidUtil;
 import micdoodle8.mods.galacticraft.core.util.GCLog;
-import micdoodle8.mods.galacticraft.core.util.VersionUtil;
 import micdoodle8.mods.galacticraft.core.wrappers.FlagData;
 import micdoodle8.mods.galacticraft.core.wrappers.Footprint;
 
@@ -313,7 +313,9 @@ public class NetworkUtil {
         }
         final byte[] compressedNBT = new byte[dataLength];
         buffer.readBytes(compressedNBT);
-        return VersionUtil.decompressNBT(compressedNBT);
+
+        final NBTSizeTracker nbtSizeTracker = new NBTSizeTracker(2097152L);
+        return CompressedStreamTools.func_152457_a(compressedNBT, nbtSizeTracker); // decompress
     }
 
     public static void writeNBTTagCompound(NBTTagCompound nbt, ByteBuf buffer) throws IOException {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/network/PacketSimple.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/network/PacketSimple.java
@@ -94,7 +94,6 @@ import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
 import micdoodle8.mods.galacticraft.core.util.GCLog;
 import micdoodle8.mods.galacticraft.core.util.MapUtil;
 import micdoodle8.mods.galacticraft.core.util.PlayerUtil;
-import micdoodle8.mods.galacticraft.core.util.VersionUtil;
 import micdoodle8.mods.galacticraft.core.util.WorldUtil;
 import micdoodle8.mods.galacticraft.core.wrappers.FlagData;
 import micdoodle8.mods.galacticraft.core.wrappers.Footprint;
@@ -860,7 +859,7 @@ public class PacketSimple extends Packet implements IPacket {
                                 final String strUUID = (String) this.data.get(9);
                                 profile = PlayerUtil.makeOtherPlayerProfile(strName, strUUID);
                             }
-                            if (VersionUtil.mcVersion1_7_10 && !profile.getProperties().containsKey("textures")) {
+                            if (!profile.getProperties().containsKey("textures")) {
                                 GalacticraftCore.packetPipeline.sendToServer(
                                         new PacketSimple(
                                                 EnumSimplePacket.S_REQUEST_PLAYERSKIN,

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/ClientUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/ClientUtil.java
@@ -18,7 +18,7 @@ import micdoodle8.mods.galacticraft.core.wrappers.FlagData;
 public class ClientUtil {
 
     public static ScaledResolution getScaledRes(Minecraft minecraft, int width, int height) {
-        return VersionUtil.getScaledRes(minecraft, width, height);
+        return new ScaledResolution(minecraft, width, height);
     }
 
     public static FlagData updateFlagData(String playerName, boolean sendPacket) {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/ConfigManagerCore.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/ConfigManagerCore.java
@@ -628,14 +628,10 @@ public class ConfigManagerCore {
             disableUpdateCheck = prop.getBoolean(false);
             propOrder.add(prop.getName());
 
-            final boolean thisIsMC172 = VersionUtil.mcVersion1_7_2;
-            prop = config.get(Constants.CONFIG_CATEGORY_GENERAL, "Disable Biome Type Registrations", thisIsMC172);
-            prop.comment = "Biome Types will not be registered in the BiomeDictionary if this is set to true. Ignored (always true) for MC 1.7.2.";
+            prop = config.get(Constants.CONFIG_CATEGORY_GENERAL, "Disable Biome Type Registrations", false);
+            prop.comment = "Biome Types will not be registered in the BiomeDictionary if this is set to true.";
             prop.setLanguageKey("gc.configgui.disableBiomeTypeRegistrations");
-            disableBiomeTypeRegistrations = prop.getBoolean(thisIsMC172);
-            if (thisIsMC172) {
-                disableBiomeTypeRegistrations = true;
-            }
+            disableBiomeTypeRegistrations = prop.getBoolean(false);
             propOrder.add(prop.getName());
 
             prop = config.get(Constants.CONFIG_CATEGORY_GENERAL, "Enable Space Race Manager Popup", false);

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/GCCoreUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/GCCoreUtil.java
@@ -76,7 +76,7 @@ public class GCCoreUtil {
         final int nextEggID = getNextValidEggID();
         if (nextEggID < 65536) {
             EntityList.IDtoClassMapping.put(nextEggID, var0);
-            VersionUtil.putClassToIDMapping(var0, nextEggID);
+            EntityList.classToIDMapping.put(var0, nextEggID);
             EntityList.entityEggs.put(nextEggID, new EntityList.EntityEggInfo(nextEggID, back, fore));
         }
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/MapGen.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/MapGen.java
@@ -2,7 +2,6 @@ package micdoodle8.mods.galacticraft.core.util;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Random;
@@ -71,12 +70,7 @@ public class MapGen {
         this.iz = 0;
         this.biomeMapWCM = world.getWorldChunkManager();
         // this.biomeMapWorld = new WeakReference<World>(world);
-        try {
-            final Field bil = this.biomeMapWCM.getClass()
-                    .getDeclaredField(VersionUtil.getNameDynamic(VersionUtil.KEY_FIELD_BIOMEINDEXLAYER));
-            bil.setAccessible(true);
-            MapGen.biomeMapGenLayer = (GenLayer) bil.get(this.biomeMapWCM);
-        } catch (final Exception e) {}
+        MapGen.biomeMapGenLayer = this.biomeMapWCM.biomeIndexLayer;
         if (MapGen.biomeMapGenLayer == null) {
             this.calculatingMap = false;
             GCLog.debug("Failed to get gen layer from World Chunk Manager.");
@@ -170,9 +164,9 @@ public class MapGen {
     private void biomeMapOneChunk(int x0, int z0, int ix, int iz, int factor, int limit) {
         // IntCache.resetIntCache();
         // int[] biomesGrid = biomeMapGenLayer.getInts(x0 << 4, z0 << 4, 16, 16);
-        // TODO: For some reason getInts() may not work in Minecraft 1.7.2, gives a
-        // banded result where part of the
-        // array is 0
+        // TODO: This code was commented out because it did not work properly on Minecraft 1.7.2. biomeMapGenLayer is
+        // never used in this class as a result. Now that we are enforcing 1.7.10, should it be uncommented? The
+        // original issue was that "getInts() [would give] a banded result where part of the array is 0".
         this.biomesGrid = this.biomeMapWCM.getBiomeGenAt(this.biomesGrid, x0 << 4, z0 << 4, 16, 16, false);
         if (this.biomesGrid == null) {
             return;

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/PlayerUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/PlayerUtil.java
@@ -125,4 +125,8 @@ public class PlayerUtil {
     public static boolean isPlayerOnline(EntityPlayerMP player) {
         return MinecraftServer.getServer().getConfigurationManager().playerEntityList.contains(player);
     }
+
+    public static boolean isPlayerOpped(EntityPlayerMP player) {
+        return MinecraftServer.getServer().getConfigurationManager().func_152596_g(player.getGameProfile());
+    }
 }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/PlayerUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/PlayerUtil.java
@@ -96,13 +96,13 @@ public class PlayerUtil {
         if (profile == null) {
             try {
                 final UUID uuid = strUUID.isEmpty() ? UUID.randomUUID() : UUID.fromString(strUUID);
-                profile = VersionUtil.constructGameProfile(uuid, strName);
+                profile = new GameProfile(uuid, strName);
             } catch (final Exception e) {
                 e.printStackTrace();
             }
         }
         if (profile == null) {
-            profile = VersionUtil.constructGameProfile(UUID.randomUUID(), strName);
+            profile = new GameProfile(UUID.randomUUID(), strName);
         }
 
         PlayerUtil.knownSkins.put(strName, profile);

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/PlayerUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/PlayerUtil.java
@@ -22,7 +22,7 @@ public class PlayerUtil {
     public static HashMap<String, GameProfile> knownSkins = new HashMap<>();
 
     public static EntityPlayerMP getPlayerForUsernameVanilla(MinecraftServer server, String username) {
-        return VersionUtil.getPlayerForUsername(server, username);
+        return server.getConfigurationManager().func_152612_a(username); // getPlayerForUsername
     }
 
     public static EntityPlayerMP getPlayerBaseServerFromPlayerUsername(String username, boolean ignoreCase) {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
@@ -46,13 +46,11 @@ public class VersionUtil {
     // Note: in reflectionCache, currently positions 3, 5, 7, 11, 13, 15, 17 are
     // unused and 21 onwards are also free.
 
-    private static final String KEY_CLASS_TEXTURE_UTIL = "textureUtil";
     private static final String KEY_CLASS_COMMAND_BASE = "commandBase";
     private static final String KEY_CLASS_SCALED_RES = "scaledResolution";
     private static final String KEY_CLASS_RENDER_PLAYER = "renderPlayer";
     private static final String KEY_CLASS_ENTITYLIST = "entityList";
 
-    private static final String KEY_METHOD_SET_MIPMAP = "setMipMap";
     private static final String KEY_METHOD_NOTIFY_ADMINS = "notifyAdmins";
     private static final String KEY_METHOD_PLAYER_FOR_NAME = "getPlayerForUsername";
     private static final String KEY_METHOD_PLAYER_IS_OPPED = "isPlayerOpped";
@@ -99,9 +97,6 @@ public class VersionUtil {
             // "y"));
             // nodemap.put(KEY_CLASS_SCALED_RES, new
             // ObfuscationEntry("net/minecraft/client/gui/ScaledResolution", "bca"));
-            nodemap.put(
-                    KEY_CLASS_TEXTURE_UTIL,
-                    new ObfuscationEntry("net/minecraft/client/renderer/texture/TextureUtil"));
             nodemap.put(KEY_CLASS_COMMAND_BASE, new ObfuscationEntry("net/minecraft/command/CommandBase"));
             nodemap.put(KEY_CLASS_SCALED_RES, new ObfuscationEntry("net/minecraft/client/gui/ScaledResolution"));
             nodemap.put(
@@ -110,7 +105,6 @@ public class VersionUtil {
             nodemap.put(KEY_CLASS_ENTITYLIST, new ObfuscationEntry("net/minecraft/entity/EntityList"));
 
             // Method descriptions are empty, since they are not needed for reflection.
-            nodemap.put(KEY_METHOD_SET_MIPMAP, new MethodObfuscationEntry("func_152777_a", "func_152777_a", ""));
             nodemap.put(KEY_METHOD_NOTIFY_ADMINS, new MethodObfuscationEntry("func_152373_a", "func_152373_a", ""));
             nodemap.put(KEY_METHOD_PLAYER_FOR_NAME, new MethodObfuscationEntry("func_152612_a", "func_152612_a", ""));
             nodemap.put(KEY_METHOD_PLAYER_IS_OPPED, new MethodObfuscationEntry("func_152596_g", "func_152596_g", ""));
@@ -131,9 +125,6 @@ public class VersionUtil {
             // "y"));
             // nodemap.put(KEY_CLASS_SCALED_RES, new
             // ObfuscationEntry("net/minecraft/client/gui/ScaledResolution", "bam"));
-            nodemap.put(
-                    KEY_CLASS_TEXTURE_UTIL,
-                    new ObfuscationEntry("net/minecraft/client/renderer/texture/TextureUtil"));
             nodemap.put(KEY_CLASS_COMMAND_BASE, new ObfuscationEntry("net/minecraft/command/CommandBase"));
             nodemap.put(KEY_CLASS_SCALED_RES, new ObfuscationEntry("net/minecraft/client/gui/ScaledResolution"));
             nodemap.put(
@@ -141,7 +132,6 @@ public class VersionUtil {
                     new ObfuscationEntry("net/minecraft/client/renderer/entity/RenderPlayer"));
             nodemap.put(KEY_CLASS_ENTITYLIST, new ObfuscationEntry("net/minecraft/entity/EntityList"));
 
-            nodemap.put(KEY_METHOD_SET_MIPMAP, new MethodObfuscationEntry("func_147950_a", "func_147950_a", ""));
             nodemap.put(KEY_METHOD_NOTIFY_ADMINS, new MethodObfuscationEntry("notifyAdmins", "func_71522_a", ""));
             nodemap.put(
                     KEY_METHOD_PLAYER_FOR_NAME,
@@ -173,34 +163,6 @@ public class VersionUtil {
 
     public static boolean mcVersionMatches(String version) {
         return VersionParser.parseRange("[" + version + "]").containsVersion(mcVersion);
-    }
-
-    public static void setMipMap(boolean b0, boolean b1) {
-        try {
-            if (mcVersion1_7_10) {
-                Method m = (Method) reflectionCache.get(8);
-
-                if (m == null) {
-                    final Class<?> c = Class.forName(getNameDynamic(KEY_CLASS_TEXTURE_UTIL).replace('/', '.'));
-                    m = c.getMethod(getNameDynamic(KEY_METHOD_SET_MIPMAP), boolean.class, boolean.class, float.class);
-                    reflectionCache.put(8, m);
-                }
-
-                m.invoke(null, b0, b1, 1.0F);
-            } else if (mcVersion1_7_2) {
-                Method m = (Method) reflectionCache.get(8);
-
-                if (m == null) {
-                    final Class<?> c = Class.forName(getNameDynamic(KEY_CLASS_TEXTURE_UTIL).replace('/', '.'));
-                    m = c.getMethod(getNameDynamic(KEY_METHOD_SET_MIPMAP), boolean.class, boolean.class);
-                    reflectionCache.put(8, m);
-                }
-
-                m.invoke(null, b0, b1);
-            }
-        } catch (final Throwable t) {
-            t.printStackTrace();
-        }
     }
 
     public static void notifyAdmins(ICommandSender sender, ICommand command, String name, Object... objects) {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
@@ -27,13 +27,11 @@ import net.minecraft.world.World;
 import com.google.common.collect.Maps;
 import com.mojang.authlib.GameProfile;
 
-import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.common.versioning.DefaultArtifactVersion;
 import cpw.mods.fml.common.versioning.VersionParser;
 import cpw.mods.fml.relauncher.FMLInjectionData;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import micdoodle8.mods.galacticraft.core.Constants;
 import micdoodle8.mods.galacticraft.core.obfuscation.FieldObfuscationEntry;
 import micdoodle8.mods.galacticraft.core.obfuscation.MethodObfuscationEntry;
 import micdoodle8.mods.galacticraft.core.obfuscation.ObfuscationEntry;
@@ -60,7 +58,6 @@ public class VersionUtil {
     private static final String KEY_CLASS_RENDER_PLAYER = "renderPlayer";
     private static final String KEY_CLASS_ENTITYLIST = "entityList";
 
-    private static final String KEY_METHOD_SET_OWNER = "setOwner";
     private static final String KEY_METHOD_GET_OWNER = "getOwnerName";
     private static final String KEY_METHOD_CONVERT_UUID = "yggdrasilConvert";
     private static final String KEY_METHOD_DECOMPRESS_NBT = "decompress";
@@ -129,7 +126,6 @@ public class VersionUtil {
             nodemap.put(KEY_CLASS_ENTITYLIST, new ObfuscationEntry("net/minecraft/entity/EntityList"));
 
             // Method descriptions are empty, since they are not needed for reflection.
-            nodemap.put(KEY_METHOD_SET_OWNER, new MethodObfuscationEntry("func_152115_b", "func_152115_b", ""));
             nodemap.put(KEY_METHOD_GET_OWNER, new MethodObfuscationEntry("func_152113_b", "func_152113_b", ""));
             nodemap.put(KEY_METHOD_CONVERT_UUID, new MethodObfuscationEntry("func_152719_a", "func_152719_a", ""));
             nodemap.put(KEY_METHOD_DECOMPRESS_NBT, new MethodObfuscationEntry("func_152457_a", "func_152457_a", ""));
@@ -169,7 +165,6 @@ public class VersionUtil {
                     new ObfuscationEntry("net/minecraft/client/renderer/entity/RenderPlayer"));
             nodemap.put(KEY_CLASS_ENTITYLIST, new ObfuscationEntry("net/minecraft/entity/EntityList"));
 
-            nodemap.put(KEY_METHOD_SET_OWNER, new MethodObfuscationEntry("setOwner", "func_70910_a", ""));
             nodemap.put(KEY_METHOD_GET_OWNER, new MethodObfuscationEntry("getOwnerName", "func_70905_p", ""));
             nodemap.put(KEY_METHOD_CONVERT_UUID, new MethodObfuscationEntry("", "", "")); // Not part of 1.7.2
             nodemap.put(KEY_METHOD_DECOMPRESS_NBT, new MethodObfuscationEntry("decompress", "func_74792_a", ""));
@@ -205,22 +200,6 @@ public class VersionUtil {
 
     public static boolean mcVersionMatches(String version) {
         return VersionParser.parseRange("[" + version + "]").containsVersion(mcVersion);
-    }
-
-    @Optional.Method(modid = Constants.MOD_ID_PLANETS)
-    public static void setSlimelingOwner(EntitySlimeling slimeling, String ownerName) {
-        try {
-            Method m = (Method) reflectionCache.get(0);
-
-            if (m == null) {
-                m = slimeling.getClass().getSuperclass().getMethod(getNameDynamic(KEY_METHOD_SET_OWNER), String.class);
-                reflectionCache.put(0, m);
-            }
-
-            m.invoke(slimeling, ownerName);
-        } catch (final Throwable t) {
-            t.printStackTrace();
-        }
     }
 
     public static String getSlimelingOwner(EntitySlimeling slimeling) {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
@@ -12,8 +12,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.AbstractClientPlayer;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.settings.GameSettings;
-import net.minecraft.command.ICommand;
-import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
@@ -46,12 +44,10 @@ public class VersionUtil {
     // Note: in reflectionCache, currently positions 3, 5, 7, 11, 13, 15, 17 are
     // unused and 21 onwards are also free.
 
-    private static final String KEY_CLASS_COMMAND_BASE = "commandBase";
     private static final String KEY_CLASS_SCALED_RES = "scaledResolution";
     private static final String KEY_CLASS_RENDER_PLAYER = "renderPlayer";
     private static final String KEY_CLASS_ENTITYLIST = "entityList";
 
-    private static final String KEY_METHOD_NOTIFY_ADMINS = "notifyAdmins";
     private static final String KEY_METHOD_PLAYER_FOR_NAME = "getPlayerForUsername";
     private static final String KEY_METHOD_PLAYER_IS_OPPED = "isPlayerOpped";
     private static final String KEY_METHOD_PLAYER_TEXTURE = "getEntityTexture";
@@ -97,7 +93,6 @@ public class VersionUtil {
             // "y"));
             // nodemap.put(KEY_CLASS_SCALED_RES, new
             // ObfuscationEntry("net/minecraft/client/gui/ScaledResolution", "bca"));
-            nodemap.put(KEY_CLASS_COMMAND_BASE, new ObfuscationEntry("net/minecraft/command/CommandBase"));
             nodemap.put(KEY_CLASS_SCALED_RES, new ObfuscationEntry("net/minecraft/client/gui/ScaledResolution"));
             nodemap.put(
                     KEY_CLASS_RENDER_PLAYER,
@@ -105,7 +100,6 @@ public class VersionUtil {
             nodemap.put(KEY_CLASS_ENTITYLIST, new ObfuscationEntry("net/minecraft/entity/EntityList"));
 
             // Method descriptions are empty, since they are not needed for reflection.
-            nodemap.put(KEY_METHOD_NOTIFY_ADMINS, new MethodObfuscationEntry("func_152373_a", "func_152373_a", ""));
             nodemap.put(KEY_METHOD_PLAYER_FOR_NAME, new MethodObfuscationEntry("func_152612_a", "func_152612_a", ""));
             nodemap.put(KEY_METHOD_PLAYER_IS_OPPED, new MethodObfuscationEntry("func_152596_g", "func_152596_g", ""));
             nodemap.put(KEY_METHOD_PLAYER_TEXTURE, new MethodObfuscationEntry("getEntityTexture", "func_110775_a", ""));
@@ -125,14 +119,12 @@ public class VersionUtil {
             // "y"));
             // nodemap.put(KEY_CLASS_SCALED_RES, new
             // ObfuscationEntry("net/minecraft/client/gui/ScaledResolution", "bam"));
-            nodemap.put(KEY_CLASS_COMMAND_BASE, new ObfuscationEntry("net/minecraft/command/CommandBase"));
             nodemap.put(KEY_CLASS_SCALED_RES, new ObfuscationEntry("net/minecraft/client/gui/ScaledResolution"));
             nodemap.put(
                     KEY_CLASS_RENDER_PLAYER,
                     new ObfuscationEntry("net/minecraft/client/renderer/entity/RenderPlayer"));
             nodemap.put(KEY_CLASS_ENTITYLIST, new ObfuscationEntry("net/minecraft/entity/EntityList"));
 
-            nodemap.put(KEY_METHOD_NOTIFY_ADMINS, new MethodObfuscationEntry("notifyAdmins", "func_71522_a", ""));
             nodemap.put(
                     KEY_METHOD_PLAYER_FOR_NAME,
                     new MethodObfuscationEntry("getPlayerForUsername", "func_72361_f", ""));
@@ -163,43 +155,6 @@ public class VersionUtil {
 
     public static boolean mcVersionMatches(String version) {
         return VersionParser.parseRange("[" + version + "]").containsVersion(mcVersion);
-    }
-
-    public static void notifyAdmins(ICommandSender sender, ICommand command, String name, Object... objects) {
-        try {
-            if (mcVersion1_7_10) {
-                Method m = (Method) reflectionCache.get(10);
-
-                if (m == null) {
-                    final Class<?> c = Class.forName(getNameDynamic(KEY_CLASS_COMMAND_BASE).replace('/', '.'));
-                    m = c.getMethod(
-                            getNameDynamic(KEY_METHOD_NOTIFY_ADMINS),
-                            ICommandSender.class,
-                            ICommand.class,
-                            String.class,
-                            Object[].class);
-                    reflectionCache.put(10, m);
-                }
-
-                m.invoke(null, sender, command, name, objects);
-            } else if (mcVersion1_7_2) {
-                Method m = (Method) reflectionCache.get(10);
-
-                if (m == null) {
-                    final Class<?> c = Class.forName(getNameDynamic(KEY_CLASS_COMMAND_BASE).replace('/', '.'));
-                    m = c.getMethod(
-                            getNameDynamic(KEY_METHOD_NOTIFY_ADMINS),
-                            ICommandSender.class,
-                            String.class,
-                            Object[].class);
-                    reflectionCache.put(10, m);
-                }
-
-                m.invoke(null, sender, name, objects);
-            }
-        } catch (final Throwable t) {
-            t.printStackTrace();
-        }
     }
 
     public static EntityPlayerMP getPlayerForUsername(MinecraftServer server, String username) {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
@@ -16,7 +16,6 @@ public class VersionUtil {
     private static final HashMap<String, ObfuscationEntry> nodemap = Maps.newHashMap();
 
     // Used in GCPlayerHandler etc
-    public static final String KEY_FIELD_FLOATINGTICKCOUNT = "floatingTickCount";
     public static final String KEY_FIELD_MUSICTICKER = "mcMusicTicker";
 
     public static final String KEY_FIELD_CAMERA_ZOOM = "cameraZoom";
@@ -33,7 +32,6 @@ public class VersionUtil {
         }
 
         // Same for both versions
-        nodemap.put(KEY_FIELD_FLOATINGTICKCOUNT, new ObfuscationEntry("floatingTickCount", "field_147365_f"));
         nodemap.put(KEY_FIELD_MUSICTICKER, new ObfuscationEntry("mcMusicTicker", "field_147126_aw"));
 
         nodemap.put(KEY_FIELD_CAMERA_ZOOM, new FieldObfuscationEntry("cameraZoom", "field_78503_V"));

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
@@ -18,7 +18,6 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.launchwrapper.Launch;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.ChunkCache;
 import net.minecraft.world.IBlockAccess;
@@ -47,15 +46,12 @@ public class VersionUtil {
     // Note: in reflectionCache, currently positions 3, 5, 7, 11, 13, 15, 17 are
     // unused and 21 onwards are also free.
 
-    private static final String KEY_CLASS_COMPRESSED_STREAM_TOOLS = "compressedStreamTools";
-    private static final String KEY_CLASS_NBT_SIZE_TRACKER = "nbtSizeTracker";
     private static final String KEY_CLASS_TEXTURE_UTIL = "textureUtil";
     private static final String KEY_CLASS_COMMAND_BASE = "commandBase";
     private static final String KEY_CLASS_SCALED_RES = "scaledResolution";
     private static final String KEY_CLASS_RENDER_PLAYER = "renderPlayer";
     private static final String KEY_CLASS_ENTITYLIST = "entityList";
 
-    private static final String KEY_METHOD_DECOMPRESS_NBT = "decompress";
     private static final String KEY_METHOD_SET_MIPMAP = "setMipMap";
     private static final String KEY_METHOD_NOTIFY_ADMINS = "notifyAdmins";
     private static final String KEY_METHOD_PLAYER_FOR_NAME = "getPlayerForUsername";
@@ -104,10 +100,6 @@ public class VersionUtil {
             // nodemap.put(KEY_CLASS_SCALED_RES, new
             // ObfuscationEntry("net/minecraft/client/gui/ScaledResolution", "bca"));
             nodemap.put(
-                    KEY_CLASS_COMPRESSED_STREAM_TOOLS,
-                    new ObfuscationEntry("net/minecraft/nbt/CompressedStreamTools"));
-            nodemap.put(KEY_CLASS_NBT_SIZE_TRACKER, new ObfuscationEntry("net/minecraft/nbt/NBTSizeTracker"));
-            nodemap.put(
                     KEY_CLASS_TEXTURE_UTIL,
                     new ObfuscationEntry("net/minecraft/client/renderer/texture/TextureUtil"));
             nodemap.put(KEY_CLASS_COMMAND_BASE, new ObfuscationEntry("net/minecraft/command/CommandBase"));
@@ -118,7 +110,6 @@ public class VersionUtil {
             nodemap.put(KEY_CLASS_ENTITYLIST, new ObfuscationEntry("net/minecraft/entity/EntityList"));
 
             // Method descriptions are empty, since they are not needed for reflection.
-            nodemap.put(KEY_METHOD_DECOMPRESS_NBT, new MethodObfuscationEntry("func_152457_a", "func_152457_a", ""));
             nodemap.put(KEY_METHOD_SET_MIPMAP, new MethodObfuscationEntry("func_152777_a", "func_152777_a", ""));
             nodemap.put(KEY_METHOD_NOTIFY_ADMINS, new MethodObfuscationEntry("func_152373_a", "func_152373_a", ""));
             nodemap.put(KEY_METHOD_PLAYER_FOR_NAME, new MethodObfuscationEntry("func_152612_a", "func_152612_a", ""));
@@ -141,10 +132,6 @@ public class VersionUtil {
             // nodemap.put(KEY_CLASS_SCALED_RES, new
             // ObfuscationEntry("net/minecraft/client/gui/ScaledResolution", "bam"));
             nodemap.put(
-                    KEY_CLASS_COMPRESSED_STREAM_TOOLS,
-                    new ObfuscationEntry("net/minecraft/nbt/CompressedStreamTools"));
-            nodemap.put(KEY_CLASS_NBT_SIZE_TRACKER, new ObfuscationEntry("", "")); // Not part of 1.7.2
-            nodemap.put(
                     KEY_CLASS_TEXTURE_UTIL,
                     new ObfuscationEntry("net/minecraft/client/renderer/texture/TextureUtil"));
             nodemap.put(KEY_CLASS_COMMAND_BASE, new ObfuscationEntry("net/minecraft/command/CommandBase"));
@@ -154,7 +141,6 @@ public class VersionUtil {
                     new ObfuscationEntry("net/minecraft/client/renderer/entity/RenderPlayer"));
             nodemap.put(KEY_CLASS_ENTITYLIST, new ObfuscationEntry("net/minecraft/entity/EntityList"));
 
-            nodemap.put(KEY_METHOD_DECOMPRESS_NBT, new MethodObfuscationEntry("decompress", "func_74792_a", ""));
             nodemap.put(KEY_METHOD_SET_MIPMAP, new MethodObfuscationEntry("func_147950_a", "func_147950_a", ""));
             nodemap.put(KEY_METHOD_NOTIFY_ADMINS, new MethodObfuscationEntry("notifyAdmins", "func_71522_a", ""));
             nodemap.put(
@@ -187,46 +173,6 @@ public class VersionUtil {
 
     public static boolean mcVersionMatches(String version) {
         return VersionParser.parseRange("[" + version + "]").containsVersion(mcVersion);
-    }
-
-    public static NBTTagCompound decompressNBT(byte[] compressedNBT) {
-        try {
-            if (mcVersion1_7_10) {
-                Class<?> c0 = (Class<?>) reflectionCache.get(4);
-                Method m = (Method) reflectionCache.get(6);
-
-                if (c0 == null) {
-                    c0 = Class.forName(getNameDynamic(KEY_CLASS_NBT_SIZE_TRACKER).replace('/', '.'));
-                    reflectionCache.put(4, c0);
-                }
-
-                if (m == null) {
-                    final Class<?> c = Class
-                            .forName(getNameDynamic(KEY_CLASS_COMPRESSED_STREAM_TOOLS).replace('/', '.'));
-                    m = c.getMethod(getNameDynamic(KEY_METHOD_DECOMPRESS_NBT), byte[].class, c0);
-                    reflectionCache.put(6, m);
-                }
-
-                final Object nbtSizeTracker = c0.getConstructor(long.class).newInstance(2097152L);
-                return (NBTTagCompound) m.invoke(null, compressedNBT, nbtSizeTracker);
-            }
-            if (mcVersion1_7_2) {
-                Method m = (Method) reflectionCache.get(6);
-
-                if (m == null) {
-                    final Class<?> c = Class
-                            .forName(getNameDynamic(KEY_CLASS_COMPRESSED_STREAM_TOOLS).replace('/', '.'));
-                    m = c.getMethod(getNameDynamic(KEY_METHOD_DECOMPRESS_NBT), byte[].class);
-                    reflectionCache.put(6, m);
-                }
-
-                return (NBTTagCompound) m.invoke(null, compressedNBT);
-            }
-        } catch (final Throwable t) {
-            t.printStackTrace();
-        }
-
-        return null;
     }
 
     public static void setMipMap(boolean b0, boolean b1) {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
@@ -3,7 +3,6 @@ package micdoodle8.mods.galacticraft.core.util;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.HashMap;
-import java.util.UUID;
 
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
@@ -14,7 +13,6 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
 import com.google.common.collect.Maps;
-import com.mojang.authlib.GameProfile;
 
 import cpw.mods.fml.common.versioning.DefaultArtifactVersion;
 import cpw.mods.fml.common.versioning.VersionParser;
@@ -135,29 +133,6 @@ public class VersionUtil {
             System.err.println("Could not find key: " + keyName);
             throw e;
         }
-    }
-
-    public static GameProfile constructGameProfile(UUID uuid, String strName) {
-        try {
-            Class<?> c = (Class<?>) reflectionCache.get(19);
-            if (c == null) {
-                c = Class.forName("com.mojang.authlib.GameProfile");
-                reflectionCache.put(19, c);
-            }
-
-            if (mcVersion1_7_10) {
-                return (GameProfile) c.getConstructor(UUID.class, String.class).newInstance(uuid, strName);
-            }
-
-            if (mcVersion1_7_2) {
-                return (GameProfile) c.getConstructor(String.class, String.class)
-                        .newInstance(uuid.toString().replace("-", ""), strName);
-            }
-        } catch (final Throwable t) {
-            t.printStackTrace();
-        }
-
-        return null;
     }
 
     public static World getWorld(IBlockAccess world) {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
@@ -35,7 +35,6 @@ import cpw.mods.fml.relauncher.SideOnly;
 import micdoodle8.mods.galacticraft.core.obfuscation.FieldObfuscationEntry;
 import micdoodle8.mods.galacticraft.core.obfuscation.MethodObfuscationEntry;
 import micdoodle8.mods.galacticraft.core.obfuscation.ObfuscationEntry;
-import micdoodle8.mods.galacticraft.planets.mars.entities.EntitySlimeling;
 import micdoodle8.mods.galacticraft.planets.mars.tile.TileEntitySlimelingEgg;
 
 public class VersionUtil {
@@ -58,7 +57,6 @@ public class VersionUtil {
     private static final String KEY_CLASS_RENDER_PLAYER = "renderPlayer";
     private static final String KEY_CLASS_ENTITYLIST = "entityList";
 
-    private static final String KEY_METHOD_GET_OWNER = "getOwnerName";
     private static final String KEY_METHOD_CONVERT_UUID = "yggdrasilConvert";
     private static final String KEY_METHOD_DECOMPRESS_NBT = "decompress";
     private static final String KEY_METHOD_SET_MIPMAP = "setMipMap";
@@ -126,7 +124,6 @@ public class VersionUtil {
             nodemap.put(KEY_CLASS_ENTITYLIST, new ObfuscationEntry("net/minecraft/entity/EntityList"));
 
             // Method descriptions are empty, since they are not needed for reflection.
-            nodemap.put(KEY_METHOD_GET_OWNER, new MethodObfuscationEntry("func_152113_b", "func_152113_b", ""));
             nodemap.put(KEY_METHOD_CONVERT_UUID, new MethodObfuscationEntry("func_152719_a", "func_152719_a", ""));
             nodemap.put(KEY_METHOD_DECOMPRESS_NBT, new MethodObfuscationEntry("func_152457_a", "func_152457_a", ""));
             nodemap.put(KEY_METHOD_SET_MIPMAP, new MethodObfuscationEntry("func_152777_a", "func_152777_a", ""));
@@ -165,7 +162,6 @@ public class VersionUtil {
                     new ObfuscationEntry("net/minecraft/client/renderer/entity/RenderPlayer"));
             nodemap.put(KEY_CLASS_ENTITYLIST, new ObfuscationEntry("net/minecraft/entity/EntityList"));
 
-            nodemap.put(KEY_METHOD_GET_OWNER, new MethodObfuscationEntry("getOwnerName", "func_70905_p", ""));
             nodemap.put(KEY_METHOD_CONVERT_UUID, new MethodObfuscationEntry("", "", "")); // Not part of 1.7.2
             nodemap.put(KEY_METHOD_DECOMPRESS_NBT, new MethodObfuscationEntry("decompress", "func_74792_a", ""));
             nodemap.put(KEY_METHOD_SET_MIPMAP, new MethodObfuscationEntry("func_147950_a", "func_147950_a", ""));
@@ -200,23 +196,6 @@ public class VersionUtil {
 
     public static boolean mcVersionMatches(String version) {
         return VersionParser.parseRange("[" + version + "]").containsVersion(mcVersion);
-    }
-
-    public static String getSlimelingOwner(EntitySlimeling slimeling) {
-        try {
-            Method m = (Method) reflectionCache.get(1);
-
-            if (m == null) {
-                m = slimeling.getClass().getMethod(getNameDynamic(KEY_METHOD_GET_OWNER));
-                reflectionCache.put(1, m);
-            }
-
-            return (String) m.invoke(slimeling);
-        } catch (final Throwable t) {
-            t.printStackTrace();
-        }
-
-        return "";
     }
 
     public static void readSlimelingEggFromNBT(TileEntitySlimelingEgg egg, NBTTagCompound nbt) {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
@@ -12,7 +12,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.AbstractClientPlayer;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.settings.GameSettings;
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.launchwrapper.Launch;
@@ -47,7 +46,6 @@ public class VersionUtil {
     private static final String KEY_CLASS_RENDER_PLAYER = "renderPlayer";
     private static final String KEY_CLASS_ENTITYLIST = "entityList";
 
-    private static final String KEY_METHOD_PLAYER_IS_OPPED = "isPlayerOpped";
     private static final String KEY_METHOD_PLAYER_TEXTURE = "getEntityTexture";
 
     // Used in GCPlayerHandler etc
@@ -98,7 +96,6 @@ public class VersionUtil {
             nodemap.put(KEY_CLASS_ENTITYLIST, new ObfuscationEntry("net/minecraft/entity/EntityList"));
 
             // Method descriptions are empty, since they are not needed for reflection.
-            nodemap.put(KEY_METHOD_PLAYER_IS_OPPED, new MethodObfuscationEntry("func_152596_g", "func_152596_g", ""));
             nodemap.put(KEY_METHOD_PLAYER_TEXTURE, new MethodObfuscationEntry("getEntityTexture", "func_110775_a", ""));
             sand = Blocks.sand;
         } else if (mcVersion1_7_2) {
@@ -122,7 +119,6 @@ public class VersionUtil {
                     new ObfuscationEntry("net/minecraft/client/renderer/entity/RenderPlayer"));
             nodemap.put(KEY_CLASS_ENTITYLIST, new ObfuscationEntry("net/minecraft/entity/EntityList"));
 
-            nodemap.put(KEY_METHOD_PLAYER_IS_OPPED, new MethodObfuscationEntry("isPlayerOpped", "func_72353_e", ""));
             nodemap.put(KEY_METHOD_PLAYER_TEXTURE, new MethodObfuscationEntry("getEntityTexture", "func_110775_a", ""));
 
             try {
@@ -149,37 +145,6 @@ public class VersionUtil {
 
     public static boolean mcVersionMatches(String version) {
         return VersionParser.parseRange("[" + version + "]").containsVersion(mcVersion);
-    }
-
-    public static boolean isPlayerOpped(EntityPlayerMP player) {
-        try {
-            if (mcVersion1_7_10) {
-                Method m = (Method) reflectionCache.get(14);
-
-                if (m == null) {
-                    final Class<?> c = player.mcServer.getConfigurationManager().getClass();
-                    m = c.getMethod(getNameDynamic(KEY_METHOD_PLAYER_IS_OPPED), GameProfile.class);
-                    reflectionCache.put(14, m);
-                }
-
-                return (Boolean) m.invoke(player.mcServer.getConfigurationManager(), player.getGameProfile());
-            }
-            if (mcVersion1_7_2) {
-                Method m = (Method) reflectionCache.get(14);
-
-                if (m == null) {
-                    final Class<?> c = player.mcServer.getConfigurationManager().getClass();
-                    m = c.getMethod(getNameDynamic(KEY_METHOD_PLAYER_IS_OPPED), String.class);
-                    reflectionCache.put(14, m);
-                }
-
-                return (Boolean) m.invoke(player.mcServer.getConfigurationManager(), player.getGameProfile().getName());
-            }
-        } catch (final Throwable t) {
-            t.printStackTrace();
-        }
-
-        return false;
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
@@ -1,6 +1,5 @@
 package micdoodle8.mods.galacticraft.core.util;
 
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.HashMap;
@@ -8,10 +7,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import net.minecraft.block.Block;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.AbstractClientPlayer;
-import net.minecraft.client.gui.ScaledResolution;
-import net.minecraft.client.settings.GameSettings;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.launchwrapper.Launch;
@@ -25,8 +21,6 @@ import com.mojang.authlib.GameProfile;
 import cpw.mods.fml.common.versioning.DefaultArtifactVersion;
 import cpw.mods.fml.common.versioning.VersionParser;
 import cpw.mods.fml.relauncher.FMLInjectionData;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 import micdoodle8.mods.galacticraft.core.obfuscation.FieldObfuscationEntry;
 import micdoodle8.mods.galacticraft.core.obfuscation.MethodObfuscationEntry;
 import micdoodle8.mods.galacticraft.core.obfuscation.ObfuscationEntry;
@@ -42,7 +36,6 @@ public class VersionUtil {
     // Note: in reflectionCache, currently positions 3, 5, 7, 11, 13, 15, 17 are
     // unused and 21 onwards are also free.
 
-    private static final String KEY_CLASS_SCALED_RES = "scaledResolution";
     private static final String KEY_CLASS_RENDER_PLAYER = "renderPlayer";
     private static final String KEY_CLASS_ENTITYLIST = "entityList";
 
@@ -89,7 +82,6 @@ public class VersionUtil {
             // "y"));
             // nodemap.put(KEY_CLASS_SCALED_RES, new
             // ObfuscationEntry("net/minecraft/client/gui/ScaledResolution", "bca"));
-            nodemap.put(KEY_CLASS_SCALED_RES, new ObfuscationEntry("net/minecraft/client/gui/ScaledResolution"));
             nodemap.put(
                     KEY_CLASS_RENDER_PLAYER,
                     new ObfuscationEntry("net/minecraft/client/renderer/entity/RenderPlayer"));
@@ -113,7 +105,6 @@ public class VersionUtil {
             // "y"));
             // nodemap.put(KEY_CLASS_SCALED_RES, new
             // ObfuscationEntry("net/minecraft/client/gui/ScaledResolution", "bam"));
-            nodemap.put(KEY_CLASS_SCALED_RES, new ObfuscationEntry("net/minecraft/client/gui/ScaledResolution"));
             nodemap.put(
                     KEY_CLASS_RENDER_PLAYER,
                     new ObfuscationEntry("net/minecraft/client/renderer/entity/RenderPlayer"));
@@ -145,38 +136,6 @@ public class VersionUtil {
 
     public static boolean mcVersionMatches(String version) {
         return VersionParser.parseRange("[" + version + "]").containsVersion(mcVersion);
-    }
-
-    @SideOnly(Side.CLIENT)
-    public static ScaledResolution getScaledRes(Minecraft mc, int width, int height) {
-        try {
-            if (mcVersion1_7_10) {
-                Constructor<?> m = (Constructor<?>) reflectionCache.get(16);
-
-                if (m == null) {
-                    final Class<?> c = Class.forName(getNameDynamic(KEY_CLASS_SCALED_RES).replace('/', '.'));
-                    m = c.getConstructor(Minecraft.class, int.class, int.class);
-                    reflectionCache.put(16, m);
-                }
-
-                return (ScaledResolution) m.newInstance(mc, width, height);
-            }
-            if (mcVersion1_7_2) {
-                Constructor<?> m = (Constructor<?>) reflectionCache.get(16);
-
-                if (m == null) {
-                    final Class<?> c = Class.forName(getNameDynamic(KEY_CLASS_SCALED_RES).replace('/', '.'));
-                    m = c.getConstructor(GameSettings.class, int.class, int.class);
-                    reflectionCache.put(16, m);
-                }
-
-                return (ScaledResolution) m.newInstance(mc.gameSettings, width, height);
-            }
-        } catch (final Throwable t) {
-            t.printStackTrace();
-        }
-
-        return null;
     }
 
     public static Method getPlayerTextureMethod() {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import net.minecraft.block.Block;
-import net.minecraft.client.entity.AbstractClientPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.launchwrapper.Launch;
@@ -36,10 +35,7 @@ public class VersionUtil {
     // Note: in reflectionCache, currently positions 3, 5, 7, 11, 13, 15, 17 are
     // unused and 21 onwards are also free.
 
-    private static final String KEY_CLASS_RENDER_PLAYER = "renderPlayer";
     private static final String KEY_CLASS_ENTITYLIST = "entityList";
-
-    private static final String KEY_METHOD_PLAYER_TEXTURE = "getEntityTexture";
 
     // Used in GCPlayerHandler etc
     public static final String KEY_FIELD_FLOATINGTICKCOUNT = "floatingTickCount";
@@ -82,13 +78,8 @@ public class VersionUtil {
             // "y"));
             // nodemap.put(KEY_CLASS_SCALED_RES, new
             // ObfuscationEntry("net/minecraft/client/gui/ScaledResolution", "bca"));
-            nodemap.put(
-                    KEY_CLASS_RENDER_PLAYER,
-                    new ObfuscationEntry("net/minecraft/client/renderer/entity/RenderPlayer"));
             nodemap.put(KEY_CLASS_ENTITYLIST, new ObfuscationEntry("net/minecraft/entity/EntityList"));
 
-            // Method descriptions are empty, since they are not needed for reflection.
-            nodemap.put(KEY_METHOD_PLAYER_TEXTURE, new MethodObfuscationEntry("getEntityTexture", "func_110775_a", ""));
             sand = Blocks.sand;
         } else if (mcVersion1_7_2) {
             // nodemap.put(KEY_CLASS_COMPRESSED_STREAM_TOOLS, new
@@ -105,12 +96,7 @@ public class VersionUtil {
             // "y"));
             // nodemap.put(KEY_CLASS_SCALED_RES, new
             // ObfuscationEntry("net/minecraft/client/gui/ScaledResolution", "bam"));
-            nodemap.put(
-                    KEY_CLASS_RENDER_PLAYER,
-                    new ObfuscationEntry("net/minecraft/client/renderer/entity/RenderPlayer"));
             nodemap.put(KEY_CLASS_ENTITYLIST, new ObfuscationEntry("net/minecraft/entity/EntityList"));
-
-            nodemap.put(KEY_METHOD_PLAYER_TEXTURE, new MethodObfuscationEntry("getEntityTexture", "func_110775_a", ""));
 
             try {
                 final Field sandField = Blocks.class.getField(deobfuscated ? "sand" : "field_150354_m");
@@ -136,25 +122,6 @@ public class VersionUtil {
 
     public static boolean mcVersionMatches(String version) {
         return VersionParser.parseRange("[" + version + "]").containsVersion(mcVersion);
-    }
-
-    public static Method getPlayerTextureMethod() {
-        try {
-            Method m = (Method) reflectionCache.get(18);
-
-            if (m == null) {
-                final Class<?> c = Class.forName(getNameDynamic(KEY_CLASS_RENDER_PLAYER).replace('/', '.'));
-                m = c.getMethod(getNameDynamic(KEY_METHOD_PLAYER_TEXTURE), AbstractClientPlayer.class);
-                m.setAccessible(true);
-                reflectionCache.put(18, m);
-            }
-
-            return m;
-        } catch (final Throwable t) {
-            t.printStackTrace();
-        }
-
-        return null;
     }
 
     public static void putClassToIDMapping(Class<?> mobClazz, int id) {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
@@ -35,7 +35,6 @@ import cpw.mods.fml.relauncher.SideOnly;
 import micdoodle8.mods.galacticraft.core.obfuscation.FieldObfuscationEntry;
 import micdoodle8.mods.galacticraft.core.obfuscation.MethodObfuscationEntry;
 import micdoodle8.mods.galacticraft.core.obfuscation.ObfuscationEntry;
-import micdoodle8.mods.galacticraft.planets.mars.tile.TileEntitySlimelingEgg;
 
 public class VersionUtil {
 
@@ -50,14 +49,12 @@ public class VersionUtil {
 
     private static final String KEY_CLASS_COMPRESSED_STREAM_TOOLS = "compressedStreamTools";
     private static final String KEY_CLASS_NBT_SIZE_TRACKER = "nbtSizeTracker";
-    private static final String KEY_CLASS_YGG_CONVERTER = "preYggdrasilConverter";
     private static final String KEY_CLASS_TEXTURE_UTIL = "textureUtil";
     private static final String KEY_CLASS_COMMAND_BASE = "commandBase";
     private static final String KEY_CLASS_SCALED_RES = "scaledResolution";
     private static final String KEY_CLASS_RENDER_PLAYER = "renderPlayer";
     private static final String KEY_CLASS_ENTITYLIST = "entityList";
 
-    private static final String KEY_METHOD_CONVERT_UUID = "yggdrasilConvert";
     private static final String KEY_METHOD_DECOMPRESS_NBT = "decompress";
     private static final String KEY_METHOD_SET_MIPMAP = "setMipMap";
     private static final String KEY_METHOD_NOTIFY_ADMINS = "notifyAdmins";
@@ -111,9 +108,6 @@ public class VersionUtil {
                     new ObfuscationEntry("net/minecraft/nbt/CompressedStreamTools"));
             nodemap.put(KEY_CLASS_NBT_SIZE_TRACKER, new ObfuscationEntry("net/minecraft/nbt/NBTSizeTracker"));
             nodemap.put(
-                    KEY_CLASS_YGG_CONVERTER,
-                    new ObfuscationEntry("net/minecraft/server/management/PreYggdrasilConverter"));
-            nodemap.put(
                     KEY_CLASS_TEXTURE_UTIL,
                     new ObfuscationEntry("net/minecraft/client/renderer/texture/TextureUtil"));
             nodemap.put(KEY_CLASS_COMMAND_BASE, new ObfuscationEntry("net/minecraft/command/CommandBase"));
@@ -124,7 +118,6 @@ public class VersionUtil {
             nodemap.put(KEY_CLASS_ENTITYLIST, new ObfuscationEntry("net/minecraft/entity/EntityList"));
 
             // Method descriptions are empty, since they are not needed for reflection.
-            nodemap.put(KEY_METHOD_CONVERT_UUID, new MethodObfuscationEntry("func_152719_a", "func_152719_a", ""));
             nodemap.put(KEY_METHOD_DECOMPRESS_NBT, new MethodObfuscationEntry("func_152457_a", "func_152457_a", ""));
             nodemap.put(KEY_METHOD_SET_MIPMAP, new MethodObfuscationEntry("func_152777_a", "func_152777_a", ""));
             nodemap.put(KEY_METHOD_NOTIFY_ADMINS, new MethodObfuscationEntry("func_152373_a", "func_152373_a", ""));
@@ -151,7 +144,6 @@ public class VersionUtil {
                     KEY_CLASS_COMPRESSED_STREAM_TOOLS,
                     new ObfuscationEntry("net/minecraft/nbt/CompressedStreamTools"));
             nodemap.put(KEY_CLASS_NBT_SIZE_TRACKER, new ObfuscationEntry("", "")); // Not part of 1.7.2
-            nodemap.put(KEY_CLASS_YGG_CONVERTER, new ObfuscationEntry("", "")); // Not part of 1.7.2
             nodemap.put(
                     KEY_CLASS_TEXTURE_UTIL,
                     new ObfuscationEntry("net/minecraft/client/renderer/texture/TextureUtil"));
@@ -162,7 +154,6 @@ public class VersionUtil {
                     new ObfuscationEntry("net/minecraft/client/renderer/entity/RenderPlayer"));
             nodemap.put(KEY_CLASS_ENTITYLIST, new ObfuscationEntry("net/minecraft/entity/EntityList"));
 
-            nodemap.put(KEY_METHOD_CONVERT_UUID, new MethodObfuscationEntry("", "", "")); // Not part of 1.7.2
             nodemap.put(KEY_METHOD_DECOMPRESS_NBT, new MethodObfuscationEntry("decompress", "func_74792_a", ""));
             nodemap.put(KEY_METHOD_SET_MIPMAP, new MethodObfuscationEntry("func_147950_a", "func_147950_a", ""));
             nodemap.put(KEY_METHOD_NOTIFY_ADMINS, new MethodObfuscationEntry("notifyAdmins", "func_71522_a", ""));
@@ -196,32 +187,6 @@ public class VersionUtil {
 
     public static boolean mcVersionMatches(String version) {
         return VersionParser.parseRange("[" + version + "]").containsVersion(mcVersion);
-    }
-
-    public static void readSlimelingEggFromNBT(TileEntitySlimelingEgg egg, NBTTagCompound nbt) {
-        try {
-            String s = "";
-            if (nbt.hasKey("OwnerUUID", 8)) {
-                s = nbt.getString("OwnerUUID");
-            } else if (mcVersion1_7_10) {
-                Method m = (Method) reflectionCache.get(2);
-
-                if (m == null) {
-                    final Class<?> c = Class.forName(getNameDynamic(KEY_CLASS_YGG_CONVERTER).replace('/', '.'));
-                    m = c.getMethod(getNameDynamic(KEY_METHOD_CONVERT_UUID), String.class);
-                    reflectionCache.put(2, m);
-                }
-
-                final String s1 = nbt.getString("Owner");
-                s = (String) m.invoke(null, s1);
-            }
-
-            if (s.length() > 0) {
-                egg.lastTouchedPlayerUUID = s;
-            }
-        } catch (final Throwable t) {
-            t.printStackTrace();
-        }
     }
 
     public static NBTTagCompound decompressNBT(byte[] compressedNBT) {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
@@ -6,18 +6,12 @@ import net.minecraft.launchwrapper.Launch;
 
 import com.google.common.collect.Maps;
 
-import cpw.mods.fml.common.versioning.DefaultArtifactVersion;
-import cpw.mods.fml.common.versioning.VersionParser;
-import cpw.mods.fml.relauncher.FMLInjectionData;
 import micdoodle8.mods.galacticraft.core.obfuscation.FieldObfuscationEntry;
 import micdoodle8.mods.galacticraft.core.obfuscation.MethodObfuscationEntry;
 import micdoodle8.mods.galacticraft.core.obfuscation.ObfuscationEntry;
 
 public class VersionUtil {
 
-    private static DefaultArtifactVersion mcVersion = null;
-    public static boolean mcVersion1_7_2 = false;
-    public static boolean mcVersion1_7_10 = false;
     private static boolean deobfuscated = true;
     private static final HashMap<String, ObfuscationEntry> nodemap = Maps.newHashMap();
 
@@ -33,10 +27,6 @@ public class VersionUtil {
     public static final String KEY_METHOD_ORIENT_CAMERA = "orientCamera";
 
     static {
-        mcVersion = new DefaultArtifactVersion((String) FMLInjectionData.data()[4]);
-        mcVersion1_7_2 = VersionUtil.mcVersionMatches("1.7.2");
-        mcVersion1_7_10 = VersionUtil.mcVersionMatches("1.7.10");
-
         try {
             deobfuscated = Launch.classLoader.getClassBytes("net.minecraft.world.World") != null;
         } catch (final Exception e) {
@@ -53,10 +43,6 @@ public class VersionUtil {
         nodemap.put(KEY_FIELD_CAMERA_PITCH, new FieldObfuscationEntry("cameraPitch", "field_78509_X"));
 
         nodemap.put(KEY_METHOD_ORIENT_CAMERA, new MethodObfuscationEntry("orientCamera", "func_78467_g", ""));
-    }
-
-    public static boolean mcVersionMatches(String version) {
-        return VersionParser.parseRange("[" + version + "]").containsVersion(mcVersion);
     }
 
     private static String getName(String keyName) {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
@@ -17,7 +17,6 @@ public class VersionUtil {
 
     // Used in GCPlayerHandler etc
     public static final String KEY_FIELD_FLOATINGTICKCOUNT = "floatingTickCount";
-    public static final String KEY_FIELD_BIOMEINDEXLAYER = "biomeIndexLayer";
     public static final String KEY_FIELD_MUSICTICKER = "mcMusicTicker";
 
     public static final String KEY_FIELD_CAMERA_ZOOM = "cameraZoom";
@@ -35,7 +34,6 @@ public class VersionUtil {
 
         // Same for both versions
         nodemap.put(KEY_FIELD_FLOATINGTICKCOUNT, new ObfuscationEntry("floatingTickCount", "field_147365_f"));
-        nodemap.put(KEY_FIELD_BIOMEINDEXLAYER, new ObfuscationEntry("biomeIndexLayer", "field_76945_e"));
         nodemap.put(KEY_FIELD_MUSICTICKER, new ObfuscationEntry("mcMusicTicker", "field_147126_aw"));
 
         nodemap.put(KEY_FIELD_CAMERA_ZOOM, new FieldObfuscationEntry("cameraZoom", "field_78503_V"));

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
@@ -1,10 +1,7 @@
 package micdoodle8.mods.galacticraft.core.util;
 
-import java.lang.reflect.Field;
 import java.util.HashMap;
 
-import net.minecraft.block.Block;
-import net.minecraft.init.Blocks;
 import net.minecraft.launchwrapper.Launch;
 
 import com.google.common.collect.Maps;
@@ -34,7 +31,6 @@ public class VersionUtil {
     public static final String KEY_FIELD_CAMERA_PITCH = "cameraPitch";
 
     public static final String KEY_METHOD_ORIENT_CAMERA = "orientCamera";
-    public static Block sand;
 
     static {
         mcVersion = new DefaultArtifactVersion((String) FMLInjectionData.data()[4]);
@@ -45,48 +41,6 @@ public class VersionUtil {
             deobfuscated = Launch.classLoader.getClassBytes("net.minecraft.world.World") != null;
         } catch (final Exception e) {
             e.printStackTrace();
-        }
-
-        if (mcVersion1_7_10) {
-            // nodemap.put(KEY_CLASS_COMPRESSED_STREAM_TOOLS, new
-            // ObfuscationEntry("net/minecraft/nbt/CompressedStreamTools", "du"));
-            // nodemap.put(KEY_CLASS_NBT_SIZE_TRACKER, new
-            // ObfuscationEntry("net/minecraft/nbt/NBTSizeTracker", "ds"));
-            // nodemap.put(KEY_CLASS_YGG_CONVERTER, new
-            // ObfuscationEntry("net/minecraft/server/management/PreYggdrasilConverter",
-            // "nz"));
-            // nodemap.put(KEY_CLASS_TEXTURE_UTIL, new
-            // ObfuscationEntry("net/minecraft/client/renderer/texture/TextureUtil",
-            // "bqi"));
-            // nodemap.put(KEY_CLASS_COMMAND_BASE, new
-            // ObfuscationEntry("net/minecraft/command/CommandBase",
-            // "y"));
-            // nodemap.put(KEY_CLASS_SCALED_RES, new
-            // ObfuscationEntry("net/minecraft/client/gui/ScaledResolution", "bca"));
-
-            sand = Blocks.sand;
-        } else if (mcVersion1_7_2) {
-            // nodemap.put(KEY_CLASS_COMPRESSED_STREAM_TOOLS, new
-            // ObfuscationEntry("net/minecraft/nbt/CompressedStreamTools", "dr"));
-            // nodemap.put(KEY_CLASS_NBT_SIZE_TRACKER, new ObfuscationEntry("", "")); // Not
-            // part of 1.7.2
-            // nodemap.put(KEY_CLASS_YGG_CONVERTER, new ObfuscationEntry("", "")); // Not
-            // part of 1.7.2
-            // nodemap.put(KEY_CLASS_TEXTURE_UTIL, new
-            // ObfuscationEntry("net/minecraft/client/renderer/texture/TextureUtil",
-            // "bqa"));
-            // nodemap.put(KEY_CLASS_COMMAND_BASE, new
-            // ObfuscationEntry("net/minecraft/command/CommandBase",
-            // "y"));
-            // nodemap.put(KEY_CLASS_SCALED_RES, new
-            // ObfuscationEntry("net/minecraft/client/gui/ScaledResolution", "bam"));
-
-            try {
-                final Field sandField = Blocks.class.getField(deobfuscated ? "sand" : "field_150354_m");
-                sand = (Block) sandField.get(null);
-            } catch (final Exception e) {
-                e.printStackTrace();
-            }
         }
 
         // Same for both versions

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
@@ -8,9 +8,6 @@ import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.launchwrapper.Launch;
-import net.minecraft.world.ChunkCache;
-import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.World;
 
 import com.google.common.collect.Maps;
 
@@ -40,7 +37,6 @@ public class VersionUtil {
     public static final String KEY_FIELD_CAMERA_ZOOM = "cameraZoom";
     public static final String KEY_FIELD_CAMERA_YAW = "cameraYaw";
     public static final String KEY_FIELD_CAMERA_PITCH = "cameraPitch";
-    public static final String KEY_FIELD_CHUNKCACHE_WORLDOBJ = "chunkCacheWorldObj";
 
     public static final String KEY_METHOD_ORIENT_CAMERA = "orientCamera";
     public static Block sand;
@@ -106,7 +102,6 @@ public class VersionUtil {
         nodemap.put(KEY_FIELD_CAMERA_ZOOM, new FieldObfuscationEntry("cameraZoom", "field_78503_V"));
         nodemap.put(KEY_FIELD_CAMERA_YAW, new FieldObfuscationEntry("cameraYaw", "field_78502_W"));
         nodemap.put(KEY_FIELD_CAMERA_PITCH, new FieldObfuscationEntry("cameraPitch", "field_78509_X"));
-        nodemap.put(KEY_FIELD_CHUNKCACHE_WORLDOBJ, new FieldObfuscationEntry("worldObj", "field_72815_e"));
 
         nodemap.put(KEY_METHOD_ORIENT_CAMERA, new MethodObfuscationEntry("orientCamera", "func_78467_g", ""));
     }
@@ -133,30 +128,6 @@ public class VersionUtil {
             System.err.println("Could not find key: " + keyName);
             throw e;
         }
-    }
-
-    public static World getWorld(IBlockAccess world) {
-        if (world instanceof World) {
-            return (World) world;
-        }
-
-        if (world instanceof ChunkCache) {
-            try {
-                Field f = (Field) reflectionCache.get(20);
-                if (f == null) {
-                    final Class<?> c = Class.forName("net.minecraft.world.ChunkCache");
-                    f = c.getDeclaredField(getNameDynamic(KEY_FIELD_CHUNKCACHE_WORLDOBJ));
-                    f.setAccessible(true);
-                    reflectionCache.put(20, f);
-                }
-
-                return (World) f.get(world);
-            } catch (final Throwable t) {
-                t.printStackTrace();
-            }
-        }
-
-        return null;
     }
 
     public static ItemStack createStack(Block block, int meta) {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
@@ -3,7 +3,6 @@ package micdoodle8.mods.galacticraft.core.util;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 
 import net.minecraft.block.Block;
@@ -35,8 +34,6 @@ public class VersionUtil {
     // Note: in reflectionCache, currently positions 3, 5, 7, 11, 13, 15, 17 are
     // unused and 21 onwards are also free.
 
-    private static final String KEY_CLASS_ENTITYLIST = "entityList";
-
     // Used in GCPlayerHandler etc
     public static final String KEY_FIELD_FLOATINGTICKCOUNT = "floatingTickCount";
     public static final String KEY_FIELD_BIOMEINDEXLAYER = "biomeIndexLayer";
@@ -45,7 +42,6 @@ public class VersionUtil {
     public static final String KEY_FIELD_CAMERA_ZOOM = "cameraZoom";
     public static final String KEY_FIELD_CAMERA_YAW = "cameraYaw";
     public static final String KEY_FIELD_CAMERA_PITCH = "cameraPitch";
-    public static final String KEY_FIELD_CLASSTOIDMAPPING = "classToIDMapping";
     public static final String KEY_FIELD_CHUNKCACHE_WORLDOBJ = "chunkCacheWorldObj";
 
     public static final String KEY_METHOD_ORIENT_CAMERA = "orientCamera";
@@ -78,7 +74,6 @@ public class VersionUtil {
             // "y"));
             // nodemap.put(KEY_CLASS_SCALED_RES, new
             // ObfuscationEntry("net/minecraft/client/gui/ScaledResolution", "bca"));
-            nodemap.put(KEY_CLASS_ENTITYLIST, new ObfuscationEntry("net/minecraft/entity/EntityList"));
 
             sand = Blocks.sand;
         } else if (mcVersion1_7_2) {
@@ -96,7 +91,6 @@ public class VersionUtil {
             // "y"));
             // nodemap.put(KEY_CLASS_SCALED_RES, new
             // ObfuscationEntry("net/minecraft/client/gui/ScaledResolution", "bam"));
-            nodemap.put(KEY_CLASS_ENTITYLIST, new ObfuscationEntry("net/minecraft/entity/EntityList"));
 
             try {
                 final Field sandField = Blocks.class.getField(deobfuscated ? "sand" : "field_150354_m");
@@ -114,7 +108,6 @@ public class VersionUtil {
         nodemap.put(KEY_FIELD_CAMERA_ZOOM, new FieldObfuscationEntry("cameraZoom", "field_78503_V"));
         nodemap.put(KEY_FIELD_CAMERA_YAW, new FieldObfuscationEntry("cameraYaw", "field_78502_W"));
         nodemap.put(KEY_FIELD_CAMERA_PITCH, new FieldObfuscationEntry("cameraPitch", "field_78509_X"));
-        nodemap.put(KEY_FIELD_CLASSTOIDMAPPING, new FieldObfuscationEntry("classToIDMapping", "field_75624_e"));
         nodemap.put(KEY_FIELD_CHUNKCACHE_WORLDOBJ, new FieldObfuscationEntry("worldObj", "field_72815_e"));
 
         nodemap.put(KEY_METHOD_ORIENT_CAMERA, new MethodObfuscationEntry("orientCamera", "func_78467_g", ""));
@@ -122,40 +115,6 @@ public class VersionUtil {
 
     public static boolean mcVersionMatches(String version) {
         return VersionParser.parseRange("[" + version + "]").containsVersion(mcVersion);
-    }
-
-    public static void putClassToIDMapping(Class<?> mobClazz, int id) {
-        // Achieves this, with private field:
-        // EntityList.classToIDMapping.put(mobClazz, id);
-        try {
-            final Class<?> c = Class.forName(getNameDynamic(KEY_CLASS_ENTITYLIST).replace('/', '.'));
-            final Field f = c.getDeclaredField(getNameDynamic(KEY_FIELD_CLASSTOIDMAPPING));
-            f.setAccessible(true);
-            @SuppressWarnings("unchecked")
-            final Map<Class<?>, Integer> classToIDMapping = (Map<Class<?>, Integer>) f.get(null);
-            classToIDMapping.put(mobClazz, id);
-        } catch (final Throwable t) {
-            t.printStackTrace();
-        }
-    }
-
-    public static int getClassToIDMapping(Class<?> mobClazz) {
-        // Achieves this, with private field:
-        // EntityList.classToIDMapping.put(mobClazz, id);
-        try {
-            final Class<?> c = Class.forName(getNameDynamic(KEY_CLASS_ENTITYLIST).replace('/', '.'));
-            final Field f = c.getDeclaredField(getNameDynamic(KEY_FIELD_CLASSTOIDMAPPING));
-            f.setAccessible(true);
-            @SuppressWarnings("unchecked")
-            final Map<Class<?>, Integer> classToIDMapping = (Map<Class<?>, Integer>) f.get(null);
-            final Integer i = classToIDMapping.get(mobClazz);
-
-            return i != null ? i : 0;
-        } catch (final Throwable t) {
-            t.printStackTrace();
-        }
-
-        return 0;
     }
 
     private static String getName(String keyName) {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
@@ -1,12 +1,10 @@
 package micdoodle8.mods.galacticraft.core.util;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.HashMap;
 
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
-import net.minecraft.item.ItemStack;
 import net.minecraft.launchwrapper.Launch;
 
 import com.google.common.collect.Maps;
@@ -25,9 +23,6 @@ public class VersionUtil {
     public static boolean mcVersion1_7_10 = false;
     private static boolean deobfuscated = true;
     private static final HashMap<String, ObfuscationEntry> nodemap = Maps.newHashMap();
-    private static final HashMap<Integer, Object> reflectionCache = Maps.newHashMap();
-    // Note: in reflectionCache, currently positions 3, 5, 7, 11, 13, 15, 17 are
-    // unused and 21 onwards are also free.
 
     // Used in GCPlayerHandler etc
     public static final String KEY_FIELD_FLOATINGTICKCOUNT = "floatingTickCount";
@@ -128,29 +123,5 @@ public class VersionUtil {
             System.err.println("Could not find key: " + keyName);
             throw e;
         }
-    }
-
-    public static ItemStack createStack(Block block, int meta) {
-        try {
-            Method m = (Method) reflectionCache.get(3);
-            if (m == null) {
-                final Class<?> c = Class.forName("net.minecraft.block.Block");
-                final Method[] mm = c.getDeclaredMethods();
-                for (final Method testMethod : mm) {
-                    if ("func_149644_j".equals(testMethod.getName())) {
-                        m = testMethod;
-                        break;
-                    }
-                }
-                m.setAccessible(true);
-                reflectionCache.put(3, m);
-            }
-
-            return (ItemStack) m.invoke(block, meta);
-        } catch (final Throwable t) {
-            t.printStackTrace();
-        }
-
-        return null;
     }
 }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/VersionUtil.java
@@ -16,7 +16,6 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.launchwrapper.Launch;
-import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.ChunkCache;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
@@ -48,7 +47,6 @@ public class VersionUtil {
     private static final String KEY_CLASS_RENDER_PLAYER = "renderPlayer";
     private static final String KEY_CLASS_ENTITYLIST = "entityList";
 
-    private static final String KEY_METHOD_PLAYER_FOR_NAME = "getPlayerForUsername";
     private static final String KEY_METHOD_PLAYER_IS_OPPED = "isPlayerOpped";
     private static final String KEY_METHOD_PLAYER_TEXTURE = "getEntityTexture";
 
@@ -100,7 +98,6 @@ public class VersionUtil {
             nodemap.put(KEY_CLASS_ENTITYLIST, new ObfuscationEntry("net/minecraft/entity/EntityList"));
 
             // Method descriptions are empty, since they are not needed for reflection.
-            nodemap.put(KEY_METHOD_PLAYER_FOR_NAME, new MethodObfuscationEntry("func_152612_a", "func_152612_a", ""));
             nodemap.put(KEY_METHOD_PLAYER_IS_OPPED, new MethodObfuscationEntry("func_152596_g", "func_152596_g", ""));
             nodemap.put(KEY_METHOD_PLAYER_TEXTURE, new MethodObfuscationEntry("getEntityTexture", "func_110775_a", ""));
             sand = Blocks.sand;
@@ -125,9 +122,6 @@ public class VersionUtil {
                     new ObfuscationEntry("net/minecraft/client/renderer/entity/RenderPlayer"));
             nodemap.put(KEY_CLASS_ENTITYLIST, new ObfuscationEntry("net/minecraft/entity/EntityList"));
 
-            nodemap.put(
-                    KEY_METHOD_PLAYER_FOR_NAME,
-                    new MethodObfuscationEntry("getPlayerForUsername", "func_72361_f", ""));
             nodemap.put(KEY_METHOD_PLAYER_IS_OPPED, new MethodObfuscationEntry("isPlayerOpped", "func_72353_e", ""));
             nodemap.put(KEY_METHOD_PLAYER_TEXTURE, new MethodObfuscationEntry("getEntityTexture", "func_110775_a", ""));
 
@@ -155,24 +149,6 @@ public class VersionUtil {
 
     public static boolean mcVersionMatches(String version) {
         return VersionParser.parseRange("[" + version + "]").containsVersion(mcVersion);
-    }
-
-    public static EntityPlayerMP getPlayerForUsername(MinecraftServer server, String username) {
-        try {
-            Method m = (Method) reflectionCache.get(12);
-
-            if (m == null) {
-                final Class<?> c = server.getConfigurationManager().getClass();
-                m = c.getMethod(getNameDynamic(KEY_METHOD_PLAYER_FOR_NAME), String.class);
-                reflectionCache.put(12, m);
-            }
-
-            return (EntityPlayerMP) m.invoke(server.getConfigurationManager(), username);
-        } catch (final Throwable t) {
-            t.printStackTrace();
-        }
-
-        return null;
     }
 
     public static boolean isPlayerOpped(EntityPlayerMP player) {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/WorldUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/WorldUtil.java
@@ -440,7 +440,7 @@ public class WorldUtil {
 
             if (!ConfigManagerCore.spaceStationsRequirePermission || data.getAllowedAll()
                     || data.getAllowedPlayers().contains(playerBase.getGameProfile().getName())
-                    || VersionUtil.isPlayerOpped(playerBase)) {
+                    || PlayerUtil.isPlayerOpped(playerBase)) {
                 // Satellites always reachable from their own homeworld or from its other
                 // satellites
                 if (playerBase != null) {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/WorldUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/WorldUtil.java
@@ -1750,7 +1750,7 @@ public class WorldUtil {
         }
 
         if (iba instanceof ChunkCache) {
-            return ((ChunkCache)iba).worldObj;
+            return ((ChunkCache) iba).worldObj;
         }
 
         return null;

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/WorldUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/WorldUtil.java
@@ -39,8 +39,10 @@ import net.minecraft.potion.PotionEffect;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.Vec3;
+import net.minecraft.world.ChunkCache;
 import net.minecraft.world.ChunkCoordIntPair;
 import net.minecraft.world.EnumDifficulty;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldProvider;
 import net.minecraft.world.WorldServer;
@@ -1740,5 +1742,17 @@ public class WorldUtil {
             }
         }
         world.provider.setWorldTime(newTime);
+    }
+
+    public static World getWorldFromIBlockAccess(IBlockAccess iba) {
+        if (iba instanceof World) {
+            return (World) iba;
+        }
+
+        if (iba instanceof ChunkCache) {
+            return ((ChunkCache)iba).worldObj;
+        }
+
+        return null;
     }
 }

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererHeavyNoseCone.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererHeavyNoseCone.java
@@ -2,6 +2,7 @@ package micdoodle8.mods.galacticraft.planets.asteroids.client.render.item;
 
 import net.minecraft.client.renderer.ItemRenderer;
 import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.texture.TextureUtil;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraftforge.client.IItemRenderer;
@@ -13,7 +14,6 @@ import cpw.mods.fml.client.FMLClientHandler;
 import micdoodle8.mods.galacticraft.api.vector.Vector3;
 import micdoodle8.mods.galacticraft.core.dimension.SpaceRace;
 import micdoodle8.mods.galacticraft.core.dimension.SpaceRaceManager;
-import micdoodle8.mods.galacticraft.core.util.VersionUtil;
 
 public class ItemRendererHeavyNoseCone implements IItemRenderer {
 
@@ -50,7 +50,7 @@ public class ItemRendererHeavyNoseCone implements IItemRenderer {
             FMLClientHandler.instance().getClient().getTextureManager().bindTexture(
                     FMLClientHandler.instance().getClient().getTextureManager()
                             .getResourceLocation(item.getItemSpriteNumber()));
-            VersionUtil.setMipMap(false, false);
+            TextureUtil.func_152777_a(false, false, 1.0F); // setMipMap
             final Tessellator tessellator = Tessellator.instance;
             final float f = iicon.getMinU();
             final float f1 = iicon.getMaxU();

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererThermalArmor.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/client/render/item/ItemRendererThermalArmor.java
@@ -3,6 +3,7 @@ package micdoodle8.mods.galacticraft.planets.asteroids.client.render.item;
 import net.minecraft.client.renderer.ItemRenderer;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.texture.TextureUtil;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraftforge.client.IItemRenderer;
@@ -11,7 +12,6 @@ import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
 import cpw.mods.fml.client.FMLClientHandler;
-import micdoodle8.mods.galacticraft.core.util.VersionUtil;
 
 public class ItemRendererThermalArmor implements IItemRenderer {
 
@@ -46,7 +46,7 @@ public class ItemRendererThermalArmor implements IItemRenderer {
             FMLClientHandler.instance().getClient().getTextureManager().bindTexture(
                     FMLClientHandler.instance().getClient().getTextureManager()
                             .getResourceLocation(item.getItemSpriteNumber()));
-            VersionUtil.setMipMap(false, false);
+            TextureUtil.func_152777_a(false, false, 1.0F); // setMipMap
             final Tessellator tessellator = Tessellator.instance;
             final float f = iicon.getMinU();
             final float f1 = iicon.getMaxU();

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/dimension/TeleportTypeAsteroids.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/dimension/TeleportTypeAsteroids.java
@@ -3,6 +3,7 @@ package micdoodle8.mods.galacticraft.planets.asteroids.dimension;
 import java.util.Random;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityList;
 import net.minecraft.entity.passive.EntityCow;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
@@ -23,7 +24,6 @@ import micdoodle8.mods.galacticraft.core.entities.player.GCPlayerStats;
 import micdoodle8.mods.galacticraft.core.items.GCItems;
 import micdoodle8.mods.galacticraft.core.util.ConfigManagerCore;
 import micdoodle8.mods.galacticraft.core.util.GCLog;
-import micdoodle8.mods.galacticraft.core.util.VersionUtil;
 import micdoodle8.mods.galacticraft.planets.asteroids.blocks.AsteroidBlocks;
 import micdoodle8.mods.galacticraft.planets.asteroids.entities.EntityEntryPod;
 import micdoodle8.mods.galacticraft.planets.asteroids.items.AsteroidsItems;
@@ -301,7 +301,9 @@ public class TeleportTypeAsteroids implements ITeleportType {
         stats.rocketStacks[i++] = new ItemStack(GCItems.basicItem, 16, 15); // Canned food
         stats.rocketStacks[i++] = new ItemStack(Items.egg, 12);
 
-        stats.rocketStacks[i++] = new ItemStack(Items.spawn_egg, 2, VersionUtil.getClassToIDMapping(EntityCow.class));
+        Integer cowEntityID = (Integer) EntityList.classToIDMapping.get(EntityCow.class); // Don't assume cow will
+                                                                                          // always have entity ID 92
+        stats.rocketStacks[i++] = new ItemStack(Items.spawn_egg, 2, (cowEntityID != null ? cowEntityID : 0));
         stats.rocketStacks[i++] = new ItemStack(Items.potionitem, 4, 8262); // Night Vision Potion
         stats.rocketStacks[i++] = new ItemStack(MarsBlocks.machine, 1, 4); // Cryogenic Chamber
         stats.rocketStacks[i++] = new ItemStack(

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/entities/EntityAstroMiner.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/entities/EntityAstroMiner.java
@@ -49,13 +49,13 @@ import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.blocks.GCBlocks;
 import micdoodle8.mods.galacticraft.core.entities.player.GCPlayerStats;
 import micdoodle8.mods.galacticraft.core.items.GCItems;
+import micdoodle8.mods.galacticraft.core.mixins.early.minecraft.BlockAccessor;
 import micdoodle8.mods.galacticraft.core.network.IPacketReceiver;
 import micdoodle8.mods.galacticraft.core.network.PacketDynamic;
 import micdoodle8.mods.galacticraft.core.util.CompatibilityManager;
 import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
 import micdoodle8.mods.galacticraft.core.util.GCLog;
 import micdoodle8.mods.galacticraft.core.util.PlayerUtil;
-import micdoodle8.mods.galacticraft.core.util.VersionUtil;
 import micdoodle8.mods.galacticraft.core.util.WorldUtil;
 import micdoodle8.mods.galacticraft.planets.asteroids.blocks.AsteroidBlocks;
 import micdoodle8.mods.galacticraft.planets.asteroids.client.sounds.SoundUpdaterMiner;
@@ -1366,7 +1366,7 @@ public class EntityAstroMiner extends Entity
             return new ItemStack(GCItems.meteoricIronRaw);
         }
 
-        return VersionUtil.createStack(b, world.getBlockMetadata(x, y, z));
+        return ((BlockAccessor)b).invokeCreateStackedBlock(world.getBlockMetadata(x, y, z));
     }
 
     private boolean addToInventory(ItemStack itemstack) {

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/entities/EntityAstroMiner.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/entities/EntityAstroMiner.java
@@ -1366,7 +1366,7 @@ public class EntityAstroMiner extends Entity
             return new ItemStack(GCItems.meteoricIronRaw);
         }
 
-        return ((BlockAccessor)b).invokeCreateStackedBlock(world.getBlockMetadata(x, y, z));
+        return ((BlockAccessor) b).invokeCreateStackedBlock(world.getBlockMetadata(x, y, z));
     }
 
     private boolean addToInventory(ItemStack itemstack) {

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/recipe/RecipeManagerAsteroids.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/asteroids/recipe/RecipeManagerAsteroids.java
@@ -18,7 +18,6 @@ import micdoodle8.mods.galacticraft.core.blocks.GCBlocks;
 import micdoodle8.mods.galacticraft.core.items.GCItems;
 import micdoodle8.mods.galacticraft.core.util.ConfigManagerCore;
 import micdoodle8.mods.galacticraft.core.util.RecipeUtil;
-import micdoodle8.mods.galacticraft.core.util.VersionUtil;
 import micdoodle8.mods.galacticraft.planets.asteroids.blocks.AsteroidBlocks;
 import micdoodle8.mods.galacticraft.planets.asteroids.items.AsteroidsItems;
 import micdoodle8.mods.galacticraft.planets.mars.items.MarsItems;
@@ -227,7 +226,7 @@ public class RecipeManagerAsteroids {
                     'X',
                     new ItemStack(Blocks.cobblestone, 1));
             CompressorRecipes.addRecipeAdventure(
-                    new ItemStack(VersionUtil.sand, 9, 0),
+                    new ItemStack(Blocks.sand, 9, 0),
                     "XXX",
                     "XXX",
                     "XXX",
@@ -239,7 +238,7 @@ public class RecipeManagerAsteroids {
                     "XBX",
                     "XXX",
                     'X',
-                    new ItemStack(VersionUtil.sand),
+                    new ItemStack(Blocks.sand),
                     'B',
                     new ItemStack(Items.water_bucket));
             CompressorRecipes.addRecipeAdventure(
@@ -248,7 +247,7 @@ public class RecipeManagerAsteroids {
                     "FEF",
                     "XFX",
                     'X',
-                    new ItemStack(VersionUtil.sand),
+                    new ItemStack(Blocks.sand),
                     'F',
                     new ItemStack(Items.rotten_flesh),
                     'E',

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/MarsModule.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/MarsModule.java
@@ -47,7 +47,6 @@ import micdoodle8.mods.galacticraft.core.util.ColorUtil;
 import micdoodle8.mods.galacticraft.core.util.ConfigManagerCore;
 import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
 import micdoodle8.mods.galacticraft.core.util.GCLog;
-import micdoodle8.mods.galacticraft.core.util.VersionUtil;
 import micdoodle8.mods.galacticraft.planets.GalacticraftPlanets;
 import micdoodle8.mods.galacticraft.planets.GuiIdsPlanets;
 import micdoodle8.mods.galacticraft.planets.IPlanetsModule;
@@ -281,7 +280,7 @@ public class MarsModule implements IPlanetsModule {
         final int nextEggID = GCCoreUtil.getNextValidEggID();
         if (nextEggID < 65536) {
             EntityList.IDtoClassMapping.put(nextEggID, var0);
-            VersionUtil.putClassToIDMapping(var0, nextEggID);
+            EntityList.classToIDMapping.put(var0, nextEggID);
             EntityList.entityEggs.put(nextEggID, new EntityList.EntityEggInfo(nextEggID, back, fore));
         }
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/blocks/BlockSlimelingEgg.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/blocks/BlockSlimelingEgg.java
@@ -26,7 +26,6 @@ import cpw.mods.fml.relauncher.SideOnly;
 import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.items.ItemBlockDesc;
 import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
-import micdoodle8.mods.galacticraft.core.util.VersionUtil;
 import micdoodle8.mods.galacticraft.planets.GalacticraftPlanets;
 import micdoodle8.mods.galacticraft.planets.mars.MarsModule;
 import micdoodle8.mods.galacticraft.planets.mars.items.MarsItems;
@@ -78,9 +77,7 @@ public class BlockSlimelingEgg extends Block implements ITileEntityProvider, Ite
 
         if (tile instanceof TileEntitySlimelingEgg) {
             ((TileEntitySlimelingEgg) tile).timeToHatch = world.rand.nextInt(50) + 20;
-            ((TileEntitySlimelingEgg) tile).lastTouchedPlayerUUID = VersionUtil.mcVersion1_7_2
-                    ? player.getCommandSenderName()
-                    : player.getUniqueID().toString();
+            ((TileEntitySlimelingEgg) tile).lastTouchedPlayerUUID = player.getUniqueID().toString();
             ((TileEntitySlimelingEgg) tile).lastTouchedPlayerName = player.getCommandSenderName();
         }
 

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/entities/EntitySlimeling.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/entities/EntitySlimeling.java
@@ -45,7 +45,6 @@ import micdoodle8.mods.galacticraft.core.GalacticraftCore;
 import micdoodle8.mods.galacticraft.core.entities.player.GCPlayerStats;
 import micdoodle8.mods.galacticraft.core.util.ColorUtil;
 import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
-import micdoodle8.mods.galacticraft.core.util.VersionUtil;
 import micdoodle8.mods.galacticraft.core.util.WorldUtil;
 import micdoodle8.mods.galacticraft.planets.mars.MarsModuleClient;
 import micdoodle8.mods.galacticraft.planets.mars.inventory.InventorySlimeling;
@@ -462,16 +461,16 @@ public class EntitySlimeling extends EntityTameable implements IEntityBreathable
                     (float) newColor.y,
                     (float) newColor.z);
 
-            String s = VersionUtil.getSlimelingOwner(this);
+            String owner = this.func_152113_b(); // getOwner
 
-            if (s != null && s.trim().length() > 0) {
-                newSlimeling.func_152115_b(s); // setOwner
+            if (owner != null && owner.trim().length() > 0) {
+                newSlimeling.func_152115_b(owner); // setOwner
                 newSlimeling.setOwnerUsername(this.getOwnerUsername());
                 newSlimeling.setTamed(true);
             } else {
-                s = VersionUtil.getSlimelingOwner(otherSlimeling);
-                if (s != null && s.trim().length() > 0) {
-                    newSlimeling.func_152115_b(s); // setOwner
+                owner = otherSlimeling.func_152113_b(); // getOwner
+                if (owner != null && owner.trim().length() > 0) {
+                    newSlimeling.func_152115_b(owner); // setOwner
                     newSlimeling.setOwnerUsername(this.getOwnerUsername());
                     newSlimeling.setTamed(true);
                 }

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/entities/EntitySlimeling.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/entities/EntitySlimeling.java
@@ -411,10 +411,7 @@ public class EntitySlimeling extends EntityTameable implements IEntityBreathable
                     this.setAttackTarget(null);
                     this.setSittingAI(true);
                     this.setHealth(20.0F);
-                    VersionUtil.setSlimelingOwner(
-                            this,
-                            VersionUtil.mcVersion1_7_10 ? par1EntityPlayer.getUniqueID().toString()
-                                    : VersionUtil.mcVersion1_7_2 ? par1EntityPlayer.getCommandSenderName() : "");
+                    this.func_152115_b(par1EntityPlayer.getUniqueID().toString()); // setOwner
                     this.setOwnerUsername(par1EntityPlayer.getCommandSenderName());
                     this.playTameEffect(true);
                     this.worldObj.setEntityState(this, (byte) 7);
@@ -468,13 +465,13 @@ public class EntitySlimeling extends EntityTameable implements IEntityBreathable
             String s = VersionUtil.getSlimelingOwner(this);
 
             if (s != null && s.trim().length() > 0) {
-                VersionUtil.setSlimelingOwner(newSlimeling, s);
+                newSlimeling.func_152115_b(s); // setOwner
                 newSlimeling.setOwnerUsername(this.getOwnerUsername());
                 newSlimeling.setTamed(true);
             } else {
                 s = VersionUtil.getSlimelingOwner(otherSlimeling);
                 if (s != null && s.trim().length() > 0) {
-                    VersionUtil.setSlimelingOwner(newSlimeling, s);
+                    newSlimeling.func_152115_b(s); // setOwner
                     newSlimeling.setOwnerUsername(this.getOwnerUsername());
                     newSlimeling.setTamed(true);
                 }

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/tile/TileEntitySlimelingEgg.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/tile/TileEntitySlimelingEgg.java
@@ -47,7 +47,7 @@ public class TileEntitySlimelingEgg extends TileEntity {
                                 colorBlue);
 
                         slimeling.setPosition(this.xCoord + 0.5, this.yCoord + 1.0, this.zCoord + 0.5);
-                        VersionUtil.setSlimelingOwner(slimeling, this.lastTouchedPlayerUUID);
+                        slimeling.func_152115_b(this.lastTouchedPlayerUUID);
                         slimeling.setOwnerUsername(this.lastTouchedPlayerName);
 
                         if (!this.worldObj.isRemote) {

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/tile/TileEntitySlimelingEgg.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/tile/TileEntitySlimelingEgg.java
@@ -1,9 +1,9 @@
 package micdoodle8.mods.galacticraft.planets.mars.tile;
 
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.server.management.PreYggdrasilConverter;
 import net.minecraft.tileentity.TileEntity;
 
-import micdoodle8.mods.galacticraft.core.util.VersionUtil;
 import micdoodle8.mods.galacticraft.planets.mars.entities.EntitySlimeling;
 
 public class TileEntitySlimelingEgg extends TileEntity {
@@ -68,7 +68,19 @@ public class TileEntitySlimelingEgg extends TileEntity {
     public void readFromNBT(NBTTagCompound nbt) {
         super.readFromNBT(nbt);
         this.timeToHatch = nbt.getInteger("TimeToHatch");
-        VersionUtil.readSlimelingEggFromNBT(this, nbt);
+
+        String ownerUUID = "";
+        if (nbt.hasKey("OwnerUUID", 8)) {
+            ownerUUID = nbt.getString("OwnerUUID");
+        } else { // Convert data from old saves?
+            final String oldOwner = nbt.getString("Owner");
+            ownerUUID = PreYggdrasilConverter.func_152719_a(oldOwner); // convertUUID
+        }
+
+        if(ownerUUID.length() > 0) {
+            this.lastTouchedPlayerUUID = ownerUUID;
+        }
+
         this.lastTouchedPlayerName = nbt.getString("OwnerUsername");
     }
 

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/tile/TileEntitySlimelingEgg.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/tile/TileEntitySlimelingEgg.java
@@ -77,7 +77,7 @@ public class TileEntitySlimelingEgg extends TileEntity {
             ownerUUID = PreYggdrasilConverter.func_152719_a(oldOwner); // convertUUID
         }
 
-        if(ownerUUID.length() > 0) {
+        if (ownerUUID.length() > 0) {
             this.lastTouchedPlayerUUID = ownerUUID;
         }
 

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/tile/TileEntitySlimelingEgg.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/tile/TileEntitySlimelingEgg.java
@@ -47,7 +47,7 @@ public class TileEntitySlimelingEgg extends TileEntity {
                                 colorBlue);
 
                         slimeling.setPosition(this.xCoord + 0.5, this.yCoord + 1.0, this.zCoord + 0.5);
-                        slimeling.func_152115_b(this.lastTouchedPlayerUUID);
+                        slimeling.func_152115_b(this.lastTouchedPlayerUUID); // setOwner
                         slimeling.setOwnerUsername(this.lastTouchedPlayerName);
 
                         if (!this.worldObj.isRemote) {

--- a/src/main/resources/META-INF/micdoodlecore_at.cfg
+++ b/src/main/resources/META-INF/micdoodlecore_at.cfg
@@ -24,6 +24,7 @@ public net.minecraft.client.gui.GuiIngame field_73838_g #recordPlaying
 public net.minecraft.client.renderer.entity.RendererLivingEntity field_77045_g #mainModel
 public net.minecraft.entity.EntityList field_75624_e #classToIDMapping
 public net.minecraft.world.ChunkCache field_72815_e #worldObj
+public net.minecraft.world.biome.WorldChunkManager field_76945_e #biomeIndexLayer
 # Methods
 public net.minecraft.entity.player.EntityPlayer func_71053_j()V #closeScreen
 public net.minecraft.entity.player.EntityPlayerMP func_71053_j()V #closeScreen

--- a/src/main/resources/META-INF/micdoodlecore_at.cfg
+++ b/src/main/resources/META-INF/micdoodlecore_at.cfg
@@ -25,6 +25,7 @@ public net.minecraft.client.renderer.entity.RendererLivingEntity field_77045_g #
 public net.minecraft.entity.EntityList field_75624_e #classToIDMapping
 public net.minecraft.world.ChunkCache field_72815_e #worldObj
 public net.minecraft.world.biome.WorldChunkManager field_76945_e #biomeIndexLayer
+public net.minecraft.network.NetHandlerPlayServer field_147365_f #floatingTickCount
 # Methods
 public net.minecraft.entity.player.EntityPlayer func_71053_j()V #closeScreen
 public net.minecraft.entity.player.EntityPlayerMP func_71053_j()V #closeScreen

--- a/src/main/resources/META-INF/micdoodlecore_at.cfg
+++ b/src/main/resources/META-INF/micdoodlecore_at.cfg
@@ -23,6 +23,7 @@ public net.minecraft.client.audio.MusicTicker field_147676_d
 public net.minecraft.client.gui.GuiIngame field_73838_g #recordPlaying
 public net.minecraft.client.renderer.entity.RendererLivingEntity field_77045_g #mainModel
 public net.minecraft.entity.EntityList field_75624_e #classToIDMapping
+public net.minecraft.world.ChunkCache field_72815_e #worldObj
 # Methods
 public net.minecraft.entity.player.EntityPlayer func_71053_j()V #closeScreen
 public net.minecraft.entity.player.EntityPlayerMP func_71053_j()V #closeScreen

--- a/src/main/resources/META-INF/micdoodlecore_at.cfg
+++ b/src/main/resources/META-INF/micdoodlecore_at.cfg
@@ -22,6 +22,7 @@ public net.minecraft.client.audio.MusicTicker field_147678_c
 public net.minecraft.client.audio.MusicTicker field_147676_d
 public net.minecraft.client.gui.GuiIngame field_73838_g #recordPlaying
 public net.minecraft.client.renderer.entity.RendererLivingEntity field_77045_g #mainModel
+public net.minecraft.entity.EntityList field_75624_e #classToIDMapping
 # Methods
 public net.minecraft.entity.player.EntityPlayer func_71053_j()V #closeScreen
 public net.minecraft.entity.player.EntityPlayerMP func_71053_j()V #closeScreen


### PR DESCRIPTION
This PR aims to strip out all of the compatibility code in Galacticraft that allowed a single JAR to be used between 1.7.2 and 1.7.10. Chances are the changes up to now have broken 1.7.2 compat already, and GTNH is strictly 1.7.10, so there is really no use for all the extra reflection.
Also, Galacticraft breaks when other mods modify what GC is trying to reflectively access (GC expects untouched classes). This is bad behavior from other mods, but what GC is doing is nonetheless pointless because of the focus on 1.7.10.

I will be working on this PR over time; I'm aiming to have it ready to review by the end of the week.

Requires #144 