### PR TITLE
Do not log Moon Village generation coordinates when debug logging is disabled

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/world/gen/MapGenVillageMoon.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/world/gen/MapGenVillageMoon.java
@@ -9,7 +9,7 @@ import net.minecraft.world.gen.structure.MapGenStructure;
 import net.minecraft.world.gen.structure.MapGenStructureIO;
 import net.minecraft.world.gen.structure.StructureStart;
 
-import cpw.mods.fml.common.FMLLog;
+import micdoodle8.mods.galacticraft.core.util.GCLog;
 
 public class MapGenVillageMoon extends MapGenStructure {
 
@@ -73,7 +73,7 @@ public class MapGenVillageMoon extends MapGenStructure {
 
     @Override
     protected StructureStart getStructureStart(int par1, int par2) {
-        FMLLog.info("Generating Moon Village at x" + par1 * 16 + " z" + par2 * 16);
+        GCLog.debug("Generating Moon Village at x" + par1 * 16 + " z" + par2 * 16);
         return new StructureVillageStartMoon(this.worldObj, this.rand, par1, par2, this.terrainType);
     }
 


### PR DESCRIPTION
Switches from using `FMLLog#info` to using `GCLog#debug`, which will check the configuration option `enableDebug` before logging, and will prepend `Debug: ` to the log message.

There are other uses of `FMLLog` and also incorrect log levels throughout the mod, but these are minor issues and don't really create as much of a problem compared to logging the coordinates for *every moon village*. Still, I can go through and clean up the logging if that's desired too.